### PR TITLE
feat(imports): add advisory AI review assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# PostgreSQL (Prisma) — local or managed provider
+# PostgreSQL (Prisma) - local or managed provider
 DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/dr_niaraki?schema=public"
 
 # Admin (see `src/server/admin/adminSecurityConfig.ts` and `adminBootstrap.ts`)
@@ -12,13 +12,42 @@ DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/dr_niaraki?schema=public
 # Optional: restore legacy JWT admin_session in production (normally off)
 # ALLOW_LEGACY_ADMIN_JWT=1
 
-# Optional: enable custom atom cursor (default off — native cursor)
+# Optional: enable custom atom cursor (default off - native cursor)
 # NEXT_PUBLIC_ENABLE_CUSTOM_CURSOR=true
 
 # Vercel: private Blob store for DOCX bytes (set when deploying on Vercel; auto-linked from dashboard)
 # BLOB_READ_WRITE_TOKEN=
 
-# Public contact form (free Web3Forms — browser POST; get key at https://web3forms.com)
+# Public contact form (free Web3Forms - browser POST; get key at https://web3forms.com)
 # NEXT_PUBLIC_WEB3FORMS_ACCESS_KEY=
+
+# --- AI import review assistant (disabled by default; review-only, never merges/publishes) ---
+# AI_PROVIDER=none
+# Active provider: none | ollama | openrouter | groq | openai
+# AI_IMPORT_REVIEW_TIMEOUT_MS=15000
+# AI_IMPORT_REVIEW_MAX_INPUT_CHARS=30000
+# AI_IMPORT_REVIEW_RATE_LIMIT_PER_HOUR=10
+# AI_APP_REFERER=https://www.abolghasemsadeghi-n.com
+# AI_APP_TITLE="Dr Niaraki Import Review"
+
+# Ollama (self-hosted free/open-source - best when you control the server)
+# OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_MODEL=llama3.1:8b
+# OLLAMA_ALLOWED_MODELS=llama3.1:8b,qwen2.5:7b,mistral:7b
+
+# OpenRouter (hosted; free/open models may be rate-limited - not unlimited)
+# OPENROUTER_API_KEY=
+# OPENROUTER_MODEL=meta-llama/llama-3.1-8b-instruct:free
+# OPENROUTER_ALLOWED_MODELS=meta-llama/llama-3.1-8b-instruct:free
+
+# Groq (hosted; free tier rate-limited)
+# GROQ_API_KEY=
+# GROQ_MODEL=llama-3.1-8b-instant
+# GROQ_ALLOWED_MODELS=llama-3.1-8b-instant
+
+# OpenAI (optional paid hosted)
+# OPENAI_API_KEY=
+# OPENAI_MODEL=gpt-4o-mini
+# OPENAI_ALLOWED_MODELS=gpt-4o-mini
 
 # GitHub mirror (optional): GITHUB_TOKEN, GITHUB_REPO, BRANCH — used for legacy JSON commits and uploads_meta when not on Blob/DB-only paths

--- a/docs/admin-import-workflow.md
+++ b/docs/admin-import-workflow.md
@@ -77,6 +77,23 @@ Structured review blocks show **added / removed / changed** per section (profile
 
 **Merge safety** (separate from compare baseline) always evaluates against **working draft if valid, else canonical** — this drives which sections are included in **safe update**.
 
+### 6b. Optional - AI review assistant (advisory only)
+
+On the import detail page, **AI review assistant** appears after parser warnings and **before** merge controls.
+
+- **Disabled by default** (`AI_PROVIDER=none`). Enable only when you accept provider privacy/logging terms for minimized review context.
+- **Review-only:** suggestions never merge, publish, edit drafts, or change the public site. There is no "Apply suggestion" action.
+- Click **Generate AI suggestions** manually - no automatic call on page load.
+- The server sends **minimized** context (warnings, count validation, merge safety, truncated block summaries). It never sends DOCX bytes, `rawDocumentText`, or full publication/patent bodies.
+- **Provider options** (see `/admin/ai` and `.env.example`):
+  - **Ollama** - best free/open-source option when self-hosted on your VPS or machine.
+  - **OpenRouter / Groq** - hosted; may expose free or low-cost models but are **rate-limited** and subject to provider policies (not unlimited or guaranteed forever-free).
+  - **OpenAI** - optional paid hosted inference.
+- API keys and base URLs stay in **server env only**. Active provider/model are set via `AI_PROVIDER` and provider env vars (redeploy to switch).
+- AI failure or rate limits do **not** block import review, merge, draft, or publish.
+
+`POST /api/admin/imports/[id]/ai-review` (admin session + registered device required).
+
 ### 7. Choose merge mode and create working draft
 
 On **Merge into working draft**:

--- a/docs/admin-import-workflow.md
+++ b/docs/admin-import-workflow.md
@@ -91,6 +91,7 @@ On the import detail page, **AI review assistant** appears after parser warnings
   - **OpenAI** - optional paid hosted inference.
 - API keys and base URLs stay in **server env only**. Active provider/model are set via `AI_PROVIDER` and provider env vars (redeploy to switch).
 - AI failure or rate limits do **not** block import review, merge, draft, or publish.
+- Rate limiting is **best-effort** and stored in memory per server instance (not shared across serverless cold starts).
 
 `POST /api/admin/imports/[id]/ai-review` (admin session + registered device required).
 

--- a/docs/production-release-checklist.md
+++ b/docs/production-release-checklist.md
@@ -56,7 +56,7 @@ Other optional vars (`ADMIN_UPLOAD_HISTORY_PRISMA_TAKE`, `NEXT_PUBLIC_ENABLE_CUS
 | `AI_PROVIDER` | `none` (default), `ollama`, `openrouter`, `groq`, or `openai` |
 | `AI_IMPORT_REVIEW_TIMEOUT_MS` | Server timeout for provider calls (default 15000) |
 | `AI_IMPORT_REVIEW_MAX_INPUT_CHARS` | Cap on minimized review context size |
-| `AI_IMPORT_REVIEW_RATE_LIMIT_PER_HOUR` | Per-admin-session rate limit (default 10) |
+| `AI_IMPORT_REVIEW_RATE_LIMIT_PER_HOUR` | Per-admin-session rate limit (default 10); best-effort in-memory only, not shared across serverless instances |
 | `OLLAMA_*` | Self-hosted Ollama base URL, model, allowlist |
 | `OPENROUTER_*` / `GROQ_*` / `OPENAI_*` | Hosted provider API keys and allowlisted models (server-only) |
 

--- a/docs/production-release-checklist.md
+++ b/docs/production-release-checklist.md
@@ -49,6 +49,19 @@ Set these in the Vercel project (or your host’s secret manager). Names must ma
 
 Other optional vars (`ADMIN_UPLOAD_HISTORY_PRISMA_TAKE`, `NEXT_PUBLIC_ENABLE_CUSTOM_CURSOR`, GitHub mirror vars) are documented in `.env.example` and are not required for a minimal production deploy.
 
+**Optional — AI import review assistant (disabled by default):**
+
+| Variable | Purpose |
+|----------|---------|
+| `AI_PROVIDER` | `none` (default), `ollama`, `openrouter`, `groq`, or `openai` |
+| `AI_IMPORT_REVIEW_TIMEOUT_MS` | Server timeout for provider calls (default 15000) |
+| `AI_IMPORT_REVIEW_MAX_INPUT_CHARS` | Cap on minimized review context size |
+| `AI_IMPORT_REVIEW_RATE_LIMIT_PER_HOUR` | Per-admin-session rate limit (default 10) |
+| `OLLAMA_*` | Self-hosted Ollama base URL, model, allowlist |
+| `OPENROUTER_*` / `GROQ_*` / `OPENAI_*` | Hosted provider API keys and allowlisted models (server-only) |
+
+Leave `AI_PROVIDER=none` unless the operator explicitly enables advisory AI. External providers receive minimized review context only - not DOCX bytes or full raw document text. Do not enable for private CV data unless you accept provider privacy and logging terms. See [Admin import workflow - AI review](./admin-import-workflow.md#6b-optional---ai-review-assistant-advisory-only).
+
 ---
 
 ## C. Security notes
@@ -201,4 +214,4 @@ Reference: [What `safe_update` protects](./admin-import-workflow.md#what-safe_up
 
 ## After this checklist
 
-When all items pass on staging (and again on production if separate), the non-AI editorial pipeline is ready for live use. Proceed to Phase 10 AI assistant design only after operator sign-off on this checklist.
+When all items pass on staging (and again on production if separate), the editorial pipeline is ready for live use. AI import review remains **optional** and **off by default** - enable only after operator sign-off on data-minimization and provider privacy terms.

--- a/src/app/admin/AdminSubNav.tsx
+++ b/src/app/admin/AdminSubNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 const LINKS = [
   { href: '/admin/content', label: 'Site content' },
   { href: '/admin/imports', label: 'CV imports' },
+  { href: '/admin/ai', label: 'AI review' },
   { href: '/admin/upload', label: 'Upload & legacy commit' },
   { href: '/admin/history', label: 'Upload history' },
   { href: '/admin/devices', label: 'Devices' },

--- a/src/app/admin/ai/page.tsx
+++ b/src/app/admin/ai/page.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import type { AiProviderSettingsModel } from '@/app/admin/imports/importDetailTypes';
+import { TW_ACCENT_SOFT_GRADIENT } from '@/lib/ui/chromeClassStrings';
+
+export default function AdminAiSettingsPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [settings, setSettings] = useState<AiProviderSettingsModel | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const statusRes = await fetch('/api/admin/status', { credentials: 'include' });
+      const status = await statusRes.json();
+      if (!status.isLoggedIn) {
+        router.push('/admin');
+        return;
+      }
+      if (!status.hasValidDevice) {
+        router.push('/admin/devices');
+        return;
+      }
+      const res = await fetch('/api/admin/ai/settings', { credentials: 'include' });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        setError(data.message || 'Failed to load AI settings');
+        return;
+      }
+      setSettings(data.settings as AiProviderSettingsModel);
+    } catch {
+      setError('Failed to load AI settings');
+    } finally {
+      setLoading(false);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-accent-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-[60vh] px-4 py-8 ${TW_ACCENT_SOFT_GRADIENT}`}>
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="flex flex-wrap gap-4 text-sm">
+          <Link href="/admin/upload" className="text-accent-primary hover:underline">
+            &lt; Admin
+          </Link>
+          <Link href="/admin/imports" className="text-accent-primary hover:underline">
+            Imports
+          </Link>
+        </div>
+
+        <h1 className="text-2xl font-semibold text-foreground">AI review assistant</h1>
+        <p className="text-sm text-muted">
+          Review-only suggestions for DOCX import review. AI never merges, publishes, or edits site content. Disabled by
+          default (<code className="font-mono">AI_PROVIDER=none</code>).
+        </p>
+
+        {error ? <div className="card border-error/40 bg-error/5 p-4 text-sm text-error">{error}</div> : null}
+
+        {settings ? (
+          <>
+            <div className="card p-4 text-sm">
+              <p className="font-medium text-foreground">Active provider (env)</p>
+              <p className="mt-2 text-muted">
+                <span className="font-mono text-foreground">{settings.activeProvider}</span>
+                {settings.activeModel ? (
+                  <span>
+                    {' '}
+                    - model <span className="font-mono text-foreground">{settings.activeModel}</span>
+                  </span>
+                ) : null}
+              </p>
+              <p className="mt-2 text-xs text-muted">{settings.switchingNote}</p>
+            </div>
+
+            <div className="space-y-3">
+              {settings.providers.map((p) => (
+                <div
+                  key={p.id}
+                  className={`card p-4 text-sm ${p.active ? 'border-accent-primary/40' : 'border-primary/15'}`}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium text-foreground">
+                      {p.label}
+                      {p.active ? <span className="ml-2 text-xs text-accent-primary">(active)</span> : null}
+                    </p>
+                    <span className="rounded border border-primary/20 px-2 py-0.5 text-[10px] uppercase text-muted">
+                      {p.status}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs text-muted">{p.statusMessage}</p>
+                  {p.hostedNote ? <p className="mt-1 text-[11px] text-muted">{p.hostedNote}</p> : null}
+                  {p.allowedModels.length > 0 ? (
+                    <p className="mt-2 text-[11px] text-muted">
+                      Allowlisted models: <span className="font-mono">{p.allowedModels.join(', ')}</span>
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+
+            <ul className="list-disc space-y-1 pl-5 text-xs text-muted">
+              {settings.disclaimers.map((d) => (
+                <li key={d}>{d}</li>
+              ))}
+              <li>
+                Ollama is the best free/open-source option when you self-host on a VPS or local machine.
+              </li>
+              <li>
+                OpenRouter and Groq may offer free or low-cost hosted models, but access is rate-limited and controlled by
+                the provider - not unlimited or guaranteed forever-free.
+              </li>
+              <li>OpenAI is optional paid hosted inference.</li>
+              <li>
+                External providers receive minimized review context only - never DOCX bytes or full raw document text. Do
+                not enable for private CV data unless you accept provider privacy and logging terms.
+              </li>
+            </ul>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/imports/ImportAiReviewAssistantPanel.tsx
+++ b/src/app/admin/imports/ImportAiReviewAssistantPanel.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { Loader2, Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import type {
+  AiProviderSettingsModel,
+  AiReviewSectionNoteModel,
+  AiReviewSuggestionModel,
+  ReviewBaselineQuery,
+} from './importDetailTypes';
+
+type Props = {
+  importId: string;
+  baselineMode: ReviewBaselineQuery;
+};
+
+function severityClass(sev: string): string {
+  if (sev === 'danger') {
+    return 'border-error/40 bg-error/10 text-foreground';
+  }
+  if (sev === 'warning') {
+    return 'border-warning/40 bg-warning/10 text-foreground';
+  }
+  return 'border-primary/20 bg-surface-secondary/60 text-foreground';
+}
+
+function ProviderStatusBanner({ settings, loading }: { settings: AiProviderSettingsModel | null; loading: boolean }) {
+  if (loading) {
+    return <p className="mt-3 text-xs text-muted">Loading provider status...</p>;
+  }
+  const activeProvider = settings?.providers.find((p) => p.active);
+  return (
+    <div className="mt-3 rounded-md border border-primary/15 bg-surface-secondary/50 px-3 py-2 text-xs text-muted">
+      <span className="font-medium text-foreground">Active: </span>
+      {activeProvider?.label ?? 'Disabled'}
+      {settings?.activeModel ? (
+        <span className="ml-1 font-mono text-foreground">({settings.activeModel})</span>
+      ) : null}
+      {activeProvider?.statusMessage ? <p className="mt-1">{activeProvider.statusMessage}</p> : null}
+      {settings?.switchingMode === 'env_only' ? (
+        <p className="mt-1 text-[11px]">{settings.switchingNote}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function AiReviewResults({ result }: { result: AiReviewSuggestionModel }) {
+  if (result.status !== 'ok' || !result.summary) {
+    return null;
+  }
+  return (
+    <div className="mt-4 space-y-3">
+      <p className="text-sm text-foreground">{result.summary}</p>
+      {result.sectionNotes && result.sectionNotes.length > 0 ? (
+        <ul className="space-y-2">
+          {result.sectionNotes.map((note: AiReviewSectionNoteModel, i: number) => (
+            <li
+              key={`${note.sectionId}-${i}`}
+              className={`rounded-md border px-3 py-2 text-xs ${severityClass(note.severity)}`}
+            >
+              <span className="font-mono text-[10px] uppercase">{note.sectionId}</span>
+              <span className="mx-1 text-muted">-</span>
+              <span className="font-medium">{note.suggestedAction}</span>
+              <p className="mt-1">{note.message}</p>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export function ImportAiReviewAssistantPanel({ importId, baselineMode }: Props) {
+  const [settings, setSettings] = useState<AiProviderSettingsModel | null>(null);
+  const [loadingSettings, setLoadingSettings] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [result, setResult] = useState<AiReviewSuggestionModel | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSettings = useCallback(async () => {
+    setLoadingSettings(true);
+    try {
+      const res = await fetch('/api/admin/ai/settings', { credentials: 'include' });
+      const data = await res.json();
+      if (res.ok && data.ok) {
+        setSettings(data.settings as AiProviderSettingsModel);
+      }
+    } catch {
+      /* non-blocking */
+    } finally {
+      setLoadingSettings(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  const generate = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/imports/${importId}/ai-review`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ baseline: baselineMode }),
+      });
+      const data = await res.json();
+      if (data.result) {
+        setResult(data.result as AiReviewSuggestionModel);
+        if (data.result.status !== 'ok' && data.result.error) {
+          setError(data.result.error);
+        }
+      } else {
+        setError(data.message || 'AI review request failed');
+      }
+    } catch {
+      setError('AI review request failed');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const activeProvider = settings?.providers.find((p) => p.active);
+  const aiEnabled = settings?.activeProvider !== 'none' && activeProvider?.status === 'configured';
+  const disclaimers = result?.disclaimers ?? settings?.disclaimers ?? [];
+
+  return (
+    <div className="card border-primary/20 p-4" data-testid="import-ai-review-panel">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-accent-primary" aria-hidden />
+          <div>
+            <p className="text-sm font-medium text-foreground">AI review assistant</p>
+            <p className="mt-1 text-xs text-muted">
+              AI suggestions are advisory, may be wrong, and never change drafts, merge behavior, or the public site.
+            </p>
+          </div>
+        </div>
+        <Link href="/admin/ai" className="text-xs text-accent-primary hover:underline">
+          Provider settings
+        </Link>
+      </div>
+
+      <ProviderStatusBanner settings={settings} loading={loadingSettings} />
+
+      <div className="mt-4">
+        {aiEnabled ? (
+          <button
+            type="button"
+            className="btn-primary text-sm disabled:opacity-50"
+            disabled={generating}
+            onClick={() => void generate()}
+            data-testid="ai-generate-button"
+          >
+            {generating ? (
+              <>
+                <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />
+                Generating...
+              </>
+            ) : (
+              'Generate AI suggestions'
+            )}
+          </button>
+        ) : (
+          <p className="text-xs text-muted" data-testid="ai-disabled-message">
+            AI is disabled or misconfigured. Set <code className="font-mono">AI_PROVIDER</code> and provider env vars,
+            then redeploy. See{' '}
+            <Link href="/admin/ai" className="text-accent-primary hover:underline">
+              provider settings
+            </Link>
+            .
+          </p>
+        )}
+      </div>
+
+      {error ? (
+        <div className="mt-3 rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-xs text-foreground">
+          {error}
+        </div>
+      ) : null}
+
+      {result ? <AiReviewResults result={result} /> : null}
+
+      {disclaimers.length > 0 ? (
+        <ul className="mt-4 list-disc space-y-1 pl-5 text-[11px] text-muted">
+          {disclaimers.map((d) => (
+            <li key={d}>{d}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/admin/imports/ImportAiReviewAssistantPanel.tsx
+++ b/src/app/admin/imports/ImportAiReviewAssistantPanel.tsx
@@ -26,9 +26,27 @@ function severityClass(sev: string): string {
   return 'border-primary/20 bg-surface-secondary/60 text-foreground';
 }
 
-function ProviderStatusBanner({ settings, loading }: { settings: AiProviderSettingsModel | null; loading: boolean }) {
+function ProviderStatusBanner({
+  settings,
+  loading,
+  providerSettingsError,
+}: {
+  settings: AiProviderSettingsModel | null;
+  loading: boolean;
+  providerSettingsError: string | null;
+}) {
   if (loading) {
     return <p className="mt-3 text-xs text-muted">Loading provider status...</p>;
+  }
+  if (providerSettingsError) {
+    return (
+      <div
+        className="mt-3 rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-xs text-foreground"
+        data-testid="ai-provider-settings-error"
+      >
+        {providerSettingsError}
+      </div>
+    );
   }
   const activeProvider = settings?.providers.find((p) => p.active);
   return (
@@ -72,23 +90,77 @@ function AiReviewResults({ result }: { result: AiReviewSuggestionModel }) {
   );
 }
 
+function GenerateAction({
+  aiEnabled,
+  providerSettingsError,
+  loadingSettings,
+  generating,
+  onGenerate,
+}: {
+  aiEnabled: boolean;
+  providerSettingsError: string | null;
+  loadingSettings: boolean;
+  generating: boolean;
+  onGenerate: () => void;
+}) {
+  if (aiEnabled) {
+    return (
+      <button
+        type="button"
+        className="btn-primary text-sm disabled:opacity-50"
+        disabled={generating}
+        onClick={onGenerate}
+        data-testid="ai-generate-button"
+      >
+        {generating ? (
+          <>
+            <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />
+            Generating...
+          </>
+        ) : (
+          'Generate AI suggestions'
+        )}
+      </button>
+    );
+  }
+  if (providerSettingsError || loadingSettings) {
+    return null;
+  }
+  return (
+    <p className="text-xs text-muted" data-testid="ai-disabled-message">
+      AI is disabled or misconfigured. Set <code className="font-mono">AI_PROVIDER</code> and provider env vars, then
+      redeploy. See{' '}
+      <Link href="/admin/ai" className="text-accent-primary hover:underline">
+        provider settings
+      </Link>
+      .
+    </p>
+  );
+}
+
 export function ImportAiReviewAssistantPanel({ importId, baselineMode }: Props) {
   const [settings, setSettings] = useState<AiProviderSettingsModel | null>(null);
   const [loadingSettings, setLoadingSettings] = useState(true);
+  const [providerSettingsError, setProviderSettingsError] = useState<string | null>(null);
   const [generating, setGenerating] = useState(false);
   const [result, setResult] = useState<AiReviewSuggestionModel | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const loadSettings = useCallback(async () => {
     setLoadingSettings(true);
+    setProviderSettingsError(null);
     try {
       const res = await fetch('/api/admin/ai/settings', { credentials: 'include' });
       const data = await res.json();
       if (res.ok && data.ok) {
         setSettings(data.settings as AiProviderSettingsModel);
+      } else {
+        setSettings(null);
+        setProviderSettingsError('Provider status is currently unavailable.');
       }
     } catch {
-      /* non-blocking */
+      setSettings(null);
+      setProviderSettingsError('Provider status is currently unavailable.');
     } finally {
       setLoadingSettings(false);
     }
@@ -125,7 +197,11 @@ export function ImportAiReviewAssistantPanel({ importId, baselineMode }: Props) 
   };
 
   const activeProvider = settings?.providers.find((p) => p.active);
-  const aiEnabled = settings?.activeProvider !== 'none' && activeProvider?.status === 'configured';
+  const aiEnabled =
+    !providerSettingsError &&
+    !loadingSettings &&
+    settings?.activeProvider !== 'none' &&
+    activeProvider?.status === 'configured';
   const disclaimers = result?.disclaimers ?? settings?.disclaimers ?? [];
 
   return (
@@ -145,36 +221,20 @@ export function ImportAiReviewAssistantPanel({ importId, baselineMode }: Props) 
         </Link>
       </div>
 
-      <ProviderStatusBanner settings={settings} loading={loadingSettings} />
+      <ProviderStatusBanner
+        settings={settings}
+        loading={loadingSettings}
+        providerSettingsError={providerSettingsError}
+      />
 
       <div className="mt-4">
-        {aiEnabled ? (
-          <button
-            type="button"
-            className="btn-primary text-sm disabled:opacity-50"
-            disabled={generating}
-            onClick={() => void generate()}
-            data-testid="ai-generate-button"
-          >
-            {generating ? (
-              <>
-                <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />
-                Generating...
-              </>
-            ) : (
-              'Generate AI suggestions'
-            )}
-          </button>
-        ) : (
-          <p className="text-xs text-muted" data-testid="ai-disabled-message">
-            AI is disabled or misconfigured. Set <code className="font-mono">AI_PROVIDER</code> and provider env vars,
-            then redeploy. See{' '}
-            <Link href="/admin/ai" className="text-accent-primary hover:underline">
-              provider settings
-            </Link>
-            .
-          </p>
-        )}
+        <GenerateAction
+          aiEnabled={aiEnabled}
+          providerSettingsError={providerSettingsError}
+          loadingSettings={loadingSettings}
+          generating={generating}
+          onGenerate={() => void generate()}
+        />
       </div>
 
       {error ? (

--- a/src/app/admin/imports/[id]/page.tsx
+++ b/src/app/admin/imports/[id]/page.tsx
@@ -194,6 +194,7 @@ export default function AdminImportDetailPage() {
       <ImportDetailBody
         imp={imp}
         review={review}
+        baselineMode={baselineMode}
         hasDraft={hasDraft}
         merging={merging}
         mergeMsg={mergeMsg}

--- a/src/app/admin/imports/importDetailBody.tsx
+++ b/src/app/admin/imports/importDetailBody.tsx
@@ -3,9 +3,10 @@
 import Link from 'next/link';
 import React from 'react';
 
+import { ImportAiReviewAssistantPanel } from './ImportAiReviewAssistantPanel';
 import { ImportCandidateReviewPanels } from './ImportCandidateReviewPanels';
 import { ImportCandidateSummaryCard } from './ImportCandidateSummaryCard';
-import type { ImportDetailModel, ReviewPayloadModel } from './importDetailTypes';
+import type { ImportDetailModel, ReviewBaselineQuery, ReviewPayloadModel } from './importDetailTypes';
 import { ImportMergeDraftCard } from './ImportMergeDraftCard';
 import { ImportProvenanceCard } from './ImportProvenanceCard';
 import { ImportReviewWarningsPanel } from './ImportReviewWarningsPanel';
@@ -14,6 +15,7 @@ import { ImportStructuredReviewBlocks } from './ImportStructuredReviewBlocks';
 type Props = {
   imp: ImportDetailModel;
   review: ReviewPayloadModel | null;
+  baselineMode: ReviewBaselineQuery;
   hasDraft: boolean;
   merging: boolean;
   mergeMsg: string | null;
@@ -24,7 +26,16 @@ type Props = {
   ) => void;
 };
 
-export function ImportDetailBody({ imp, review, hasDraft, merging, mergeMsg, error, onMerge }: Props) {
+export function ImportDetailBody({
+  imp,
+  review,
+  baselineMode,
+  hasDraft,
+  merging,
+  mergeMsg,
+  error,
+  onMerge,
+}: Props) {
   return (
     <div className="min-h-[60vh] px-4 py-8">
       <div className="max-w-5xl mx-auto space-y-6">
@@ -55,6 +66,8 @@ export function ImportDetailBody({ imp, review, hasDraft, merging, mergeMsg, err
         <ImportCandidateReviewPanels imp={imp} review={review} />
 
         {review ? <ImportReviewWarningsPanel review={review} /> : null}
+
+        <ImportAiReviewAssistantPanel importId={imp.id} baselineMode={baselineMode} />
 
         <ImportMergeDraftCard
           imp={imp}

--- a/src/app/admin/imports/importDetailTypes.ts
+++ b/src/app/admin/imports/importDetailTypes.ts
@@ -108,3 +108,42 @@ export type ImportMergeSafetyModel = {
   /** Cross-cutting notes (unmapped sections, envelope hints, parser severity, etc.). */
   notes: string[];
 };
+
+export type AiReviewSectionNoteModel = {
+  sectionId: string;
+  severity: 'info' | 'warning' | 'danger';
+  message: string;
+  suggestedAction: 'review_manually' | 'safe_to_proceed' | 'do_not_full_replace' | 'check_counts';
+};
+
+export type AiReviewSuggestionModel = {
+  advisory: true;
+  enabled: boolean;
+  provider: string;
+  model?: string;
+  status: 'ok' | 'disabled' | 'error' | 'timeout' | 'misconfigured';
+  generatedAt: string;
+  inputHash: string;
+  summary?: string;
+  sectionNotes?: AiReviewSectionNoteModel[];
+  disclaimers: string[];
+  error?: string;
+};
+
+export type AiProviderSettingsModel = {
+  activeProvider: string;
+  activeModel: string | null;
+  switchingMode: 'env_only';
+  switchingNote: string;
+  providers: Array<{
+    id: string;
+    label: string;
+    status: string;
+    active: boolean;
+    model: string | null;
+    allowedModels: string[];
+    statusMessage: string;
+    hostedNote?: string;
+  }>;
+  disclaimers: string[];
+};

--- a/src/app/api/admin/ai/settings/route.ts
+++ b/src/app/api/admin/ai/settings/route.ts
@@ -1,0 +1,23 @@
+/**
+ * GET: AI provider configuration status (no secrets).
+ */
+
+import { NextResponse } from 'next/server';
+
+import { requireFullAdminAccessForContent } from '@/server/admin/contentWorkflowAccess';
+import { internalErrorResponse } from '@/server/admin/contentWorkflowHttp';
+import { getAiProviderSettingsView } from '@/server/ai/aiProviderSettings';
+
+export async function GET() {
+  const denied = await requireFullAdminAccessForContent();
+  if (denied) {
+    return denied;
+  }
+
+  try {
+    return NextResponse.json({ ok: true, settings: getAiProviderSettingsView() });
+  } catch (e) {
+    console.error('[ai-settings]', e);
+    return internalErrorResponse();
+  }
+}

--- a/src/app/api/admin/imports/[id]/ai-review/route.ts
+++ b/src/app/api/admin/imports/[id]/ai-review/route.ts
@@ -1,0 +1,74 @@
+/**
+ * POST: advisory AI import review suggestions (manual, on-demand).
+ */
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { requireFullAdminAccessForContent } from '@/server/admin/contentWorkflowAccess';
+import { internalErrorResponse } from '@/server/admin/contentWorkflowHttp';
+import { runImportAiReview } from '@/server/ai/runImportAiReview';
+import { parseReviewBaselineMode } from '@/server/imports/reviewBaseline';
+
+const bodySchema = z
+  .object({
+    baseline: z.enum(['auto', 'working_draft', 'canonical', 'published']).optional(),
+  })
+  .strict();
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export const maxDuration = 30;
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const denied = await requireFullAdminAccessForContent();
+  if (denied) {
+    return denied;
+  }
+
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json({ ok: false, error: 'BAD_REQUEST', message: 'Missing id' }, { status: 400 });
+  }
+
+  let body: unknown = {};
+  try {
+    const text = await request.text();
+    if (text.trim()) {
+      body = JSON.parse(text);
+    }
+  } catch {
+    return NextResponse.json({ ok: false, error: 'BAD_REQUEST', message: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'BAD_REQUEST', message: parsed.error.message },
+      { status: 400 },
+    );
+  }
+
+  const baseline = parseReviewBaselineMode(parsed.data.baseline ?? 'auto');
+
+  try {
+    const outcome = await runImportAiReview(id, baseline);
+    if ('notFound' in outcome && outcome.notFound) {
+      return NextResponse.json({ ok: false, error: 'NOT_FOUND', message: 'Import not found' }, { status: 404 });
+    }
+    if ('rateLimited' in outcome && outcome.rateLimited) {
+      return NextResponse.json(
+        { ok: true, advisory: true, rateLimited: true, result: outcome.result },
+        { status: 429 },
+      );
+    }
+    if ('ok' in outcome && outcome.ok) {
+      return NextResponse.json({ ok: true, result: outcome.result });
+    }
+    return internalErrorResponse();
+  } catch (e) {
+    console.error('[ai-review]', e);
+    return internalErrorResponse();
+  }
+}

--- a/src/server/ai/aiProviderSettings.ts
+++ b/src/server/ai/aiProviderSettings.ts
@@ -1,0 +1,140 @@
+import 'server-only';
+
+import { getAiReviewRuntimeConfig, resolveAllowlistedModel } from '@/server/ai/aiReviewConfig';
+import type { AiProviderId, AiProviderOptionView, AiProviderSettingsView, AiProviderStatus } from '@/server/ai/aiReviewTypes';
+import { AI_REVIEW_DISCLAIMERS } from '@/server/ai/aiReviewTypes';
+
+function providerStatus(id: AiProviderId, configured: boolean): AiProviderStatus {
+  if (id === 'none') {
+    return 'disabled';
+  }
+  if (!configured) {
+    return 'misconfigured';
+  }
+  return 'configured';
+}
+
+function buildOllamaView(active: boolean): AiProviderOptionView {
+  const cfg = getAiReviewRuntimeConfig();
+  const modelOk = Boolean(resolveAllowlistedModel(cfg.ollama.model, cfg.ollama.allowedModels));
+  const configured = modelOk && Boolean(cfg.ollama.baseUrl);
+  return {
+    id: 'ollama',
+    label: 'Ollama (self-hosted)',
+    status: providerStatus('ollama', configured),
+    active,
+    model: modelOk ? cfg.ollama.model : null,
+    allowedModels: cfg.ollama.allowedModels,
+    statusMessage: configured
+      ? 'Self-hosted inference via OLLAMA_BASE_URL. Best free/open-source option when you control the server.'
+      : 'Set OLLAMA_BASE_URL and an allowlisted OLLAMA_MODEL.',
+    hostedNote: 'Runs on your machine or VPS - not a third-party hosted API.',
+  };
+}
+
+function buildHostedView(
+  id: Extract<AiProviderId, 'openrouter' | 'groq' | 'openai'>,
+  label: string,
+  active: boolean,
+  apiKey: string | null,
+  model: string,
+  allowed: string[],
+  keyName: string,
+  hostedNote: string,
+): AiProviderOptionView {
+  const modelOk = Boolean(resolveAllowlistedModel(model, allowed));
+  const configured = Boolean(apiKey) && modelOk;
+  let statusMessage = `Set ${keyName} and an allowlisted model.`;
+  if (configured) {
+    statusMessage = 'API key and model configured (server-side env only).';
+  } else if (apiKey && !modelOk) {
+    statusMessage = 'API key set but model is not in allowlist.';
+  } else if (!apiKey) {
+    statusMessage = `Missing ${keyName}.`;
+  }
+  return {
+    id,
+    label,
+    status: providerStatus(id, configured),
+    active,
+    model: modelOk ? model : null,
+    allowedModels: allowed,
+    statusMessage,
+    hostedNote,
+  };
+}
+
+export function getAiProviderSettingsView(): AiProviderSettingsView {
+  const cfg = getAiReviewRuntimeConfig();
+  const active = cfg.provider;
+
+  const providers: AiProviderOptionView[] = [
+    {
+      id: 'none',
+      label: 'Disabled',
+      status: 'disabled',
+      active: active === 'none',
+      model: null,
+      allowedModels: [],
+      statusMessage: 'AI review assistant off (default).',
+    },
+    buildOllamaView(active === 'ollama'),
+    buildHostedView(
+      'openrouter',
+      'OpenRouter',
+      active === 'openrouter',
+      cfg.openrouter.apiKey,
+      cfg.openrouter.model,
+      cfg.openrouter.allowedModels,
+      'OPENROUTER_API_KEY',
+      'Hosted service; free/open models may be rate-limited and subject to provider policies - not unlimited.',
+    ),
+    buildHostedView(
+      'groq',
+      'Groq',
+      active === 'groq',
+      cfg.groq.apiKey,
+      cfg.groq.model,
+      cfg.groq.allowedModels,
+      'GROQ_API_KEY',
+      'Hosted service; free tier and model access are rate-limited and may change.',
+    ),
+    buildHostedView(
+      'openai',
+      'OpenAI',
+      active === 'openai',
+      cfg.openai.apiKey,
+      cfg.openai.model,
+      cfg.openai.allowedModels,
+      'OPENAI_API_KEY',
+      'Paid hosted API; optional for higher-quality suggestions.',
+    ),
+  ];
+
+  function activeModelForProvider(): string | null {
+    if (active === 'ollama') {
+      return resolveAllowlistedModel(cfg.ollama.model, cfg.ollama.allowedModels);
+    }
+    if (active === 'openrouter') {
+      return resolveAllowlistedModel(cfg.openrouter.model, cfg.openrouter.allowedModels);
+    }
+    if (active === 'groq') {
+      return resolveAllowlistedModel(cfg.groq.model, cfg.groq.allowedModels);
+    }
+    if (active === 'openai') {
+      return resolveAllowlistedModel(cfg.openai.model, cfg.openai.allowedModels);
+    }
+    return null;
+  }
+  const activeModel = activeModelForProvider();
+
+  return {
+    activeProvider: active,
+    activeModel,
+    switchingMode: 'env_only',
+    switchingNote:
+      'Active provider and model are set via AI_PROVIDER and provider env vars. Change env and redeploy to switch. API keys never appear in the browser.',
+    providers,
+    disclaimers: [...AI_REVIEW_DISCLAIMERS],
+  };
+}

--- a/src/server/ai/aiReviewConfig.ts
+++ b/src/server/ai/aiReviewConfig.ts
@@ -1,0 +1,101 @@
+import 'server-only';
+
+import type { AiProviderId } from '@/server/ai/aiReviewTypes';
+
+const PROVIDER_IDS: AiProviderId[] = ['none', 'ollama', 'openrouter', 'groq', 'openai'];
+
+export function parseAiProviderId(raw: string | undefined): AiProviderId {
+  const v = (raw ?? 'none').trim().toLowerCase();
+  return PROVIDER_IDS.includes(v as AiProviderId) ? (v as AiProviderId) : 'none';
+}
+
+export function parseAllowlist(raw: string | undefined, fallback: string): string[] {
+  const list = (raw ?? fallback)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.length > 0 ? list : [fallback];
+}
+
+export type AiReviewRuntimeConfig = {
+  provider: AiProviderId;
+  timeoutMs: number;
+  maxInputChars: number;
+  rateLimitPerHour: number;
+  ollama: {
+    baseUrl: string;
+    model: string;
+    allowedModels: string[];
+  };
+  openrouter: {
+    apiKey: string | null;
+    model: string;
+    allowedModels: string[];
+  };
+  groq: {
+    apiKey: string | null;
+    model: string;
+    allowedModels: string[];
+  };
+  openai: {
+    apiKey: string | null;
+    model: string;
+    allowedModels: string[];
+  };
+};
+
+export function getAiReviewRuntimeConfig(): AiReviewRuntimeConfig {
+  const ollamaDefaultModel = process.env.OLLAMA_MODEL?.trim() || 'llama3.1:8b';
+  const openrouterDefaultModel = process.env.OPENROUTER_MODEL?.trim() || 'meta-llama/llama-3.1-8b-instruct:free';
+  const groqDefaultModel = process.env.GROQ_MODEL?.trim() || 'llama-3.1-8b-instant';
+  const openaiDefaultModel = process.env.OPENAI_MODEL?.trim() || 'gpt-4o-mini';
+
+  return {
+    provider: parseAiProviderId(process.env.AI_PROVIDER),
+    timeoutMs: Math.max(3000, Number(process.env.AI_IMPORT_REVIEW_TIMEOUT_MS ?? 15000) || 15000),
+    maxInputChars: Math.max(5000, Number(process.env.AI_IMPORT_REVIEW_MAX_INPUT_CHARS ?? 30000) || 30000),
+    rateLimitPerHour: Math.max(1, Number(process.env.AI_IMPORT_REVIEW_RATE_LIMIT_PER_HOUR ?? 10) || 10),
+    ollama: {
+      baseUrl: (process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434').replace(/\/$/, ''),
+      model: ollamaDefaultModel,
+      allowedModels: parseAllowlist(process.env.OLLAMA_ALLOWED_MODELS, ollamaDefaultModel),
+    },
+    openrouter: {
+      apiKey: process.env.OPENROUTER_API_KEY?.trim() || null,
+      model: openrouterDefaultModel,
+      allowedModels: parseAllowlist(process.env.OPENROUTER_ALLOWED_MODELS, openrouterDefaultModel),
+    },
+    groq: {
+      apiKey: process.env.GROQ_API_KEY?.trim() || null,
+      model: groqDefaultModel,
+      allowedModels: parseAllowlist(process.env.GROQ_ALLOWED_MODELS, groqDefaultModel),
+    },
+    openai: {
+      apiKey: process.env.OPENAI_API_KEY?.trim() || null,
+      model: openaiDefaultModel,
+      allowedModels: parseAllowlist(process.env.OPENAI_ALLOWED_MODELS, openaiDefaultModel),
+    },
+  };
+}
+
+export function resolveAllowlistedModel(model: string, allowed: string[]): string | null {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return allowed.includes(trimmed) ? trimmed : null;
+}
+
+/** OpenRouter HTTP-Referer header (server-side only). */
+export function getAiAppReferer(): string {
+  return (
+    process.env.AI_APP_REFERER?.trim() ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    'https://www.abolghasemsadeghi-n.com'
+  );
+}
+
+/** OpenRouter X-Title header (server-side only). */
+export function getAiAppTitle(): string {
+  return process.env.AI_APP_TITLE?.trim() || 'Dr Niaraki Import Review';
+}

--- a/src/server/ai/aiReviewFetch.ts
+++ b/src/server/ai/aiReviewFetch.ts
@@ -1,14 +1,20 @@
 import 'server-only';
 
-export async function fetchWithTimeout(
+/**
+ * Fetch with timeout covering headers and full response body consumption.
+ * The abort timer is cleared only after `consume` completes.
+ */
+export async function fetchWithTimeout<T>(
   url: string,
   init: RequestInit,
   timeoutMs: number,
-): Promise<Response> {
+  consume: (response: Response) => Promise<T>,
+): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    return await consume(response);
   } finally {
     clearTimeout(timer);
   }
@@ -42,23 +48,24 @@ export async function openAiCompatibleChat(opts: {
     body.response_format = { type: 'json_object' };
   }
 
-  const res = await fetchWithTimeout(
+  return fetchWithTimeout(
     opts.url,
     { method: 'POST', headers, body: JSON.stringify(body) },
     opts.timeoutMs,
+    async (res) => {
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`Provider HTTP ${res.status}: ${text.slice(0, 300)}`);
+      }
+
+      const data = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      const content = data.choices?.[0]?.message?.content;
+      if (!content) {
+        throw new Error('Provider returned empty completion');
+      }
+      return content;
+    },
   );
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Provider HTTP ${res.status}: ${text.slice(0, 300)}`);
-  }
-
-  const data = (await res.json()) as {
-    choices?: Array<{ message?: { content?: string } }>;
-  };
-  const content = data.choices?.[0]?.message?.content;
-  if (!content) {
-    throw new Error('Provider returned empty completion');
-  }
-  return content;
 }

--- a/src/server/ai/aiReviewFetch.ts
+++ b/src/server/ai/aiReviewFetch.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type ChatMessage = { role: 'system' | 'user'; content: string };
+
+export async function openAiCompatibleChat(opts: {
+  url: string;
+  apiKey?: string;
+  extraHeaders?: Record<string, string>;
+  model: string;
+  messages: ChatMessage[];
+  timeoutMs: number;
+  responseFormatJson?: boolean;
+}): Promise<string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...opts.extraHeaders,
+  };
+  if (opts.apiKey) {
+    headers.Authorization = `Bearer ${opts.apiKey}`;
+  }
+
+  const body: Record<string, unknown> = {
+    model: opts.model,
+    messages: opts.messages,
+    temperature: 0.2,
+  };
+  if (opts.responseFormatJson) {
+    body.response_format = { type: 'json_object' };
+  }
+
+  const res = await fetchWithTimeout(
+    opts.url,
+    { method: 'POST', headers, body: JSON.stringify(body) },
+    opts.timeoutMs,
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Provider HTTP ${res.status}: ${text.slice(0, 300)}`);
+  }
+
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error('Provider returned empty completion');
+  }
+  return content;
+}

--- a/src/server/ai/aiReviewParse.ts
+++ b/src/server/ai/aiReviewParse.ts
@@ -19,17 +19,55 @@ const LlmJsonSchema = z.object({
     .optional(),
 });
 
-export function parseLlmJsonContent(raw: string): { summary: string; sectionNotes?: AiReviewSectionNote[] } | null {
-  const trimmed = raw.trim();
-  const jsonText = trimmed.startsWith('```')
-    ? trimmed.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '')
-    : trimmed;
+type ParsedLlmJson = { summary: string; sectionNotes?: AiReviewSectionNote[] };
+
+function tryParseCandidate(jsonText: string): ParsedLlmJson | null {
   try {
-    const parsed = LlmJsonSchema.parse(JSON.parse(jsonText));
-    return parsed;
+    return LlmJsonSchema.parse(JSON.parse(jsonText));
   } catch {
     return null;
   }
+}
+
+function extractJsonCandidates(raw: string): string[] {
+  const candidates: string[] = [];
+  const trimmed = raw.trim();
+  if (trimmed) {
+    candidates.push(trimmed);
+  }
+
+  const fenceRe = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let match = fenceRe.exec(raw);
+  while (match) {
+    const block = match[1]?.trim();
+    if (block) {
+      candidates.push(block);
+    }
+    match = fenceRe.exec(raw);
+  }
+
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    candidates.push(raw.slice(start, end + 1).trim());
+  }
+
+  return candidates;
+}
+
+export function parseLlmJsonContent(raw: string): ParsedLlmJson | null {
+  const seen = new Set<string>();
+  for (const candidate of extractJsonCandidates(raw)) {
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    const parsed = tryParseCandidate(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return null;
 }
 
 export function advisoryErrorResult(

--- a/src/server/ai/aiReviewParse.ts
+++ b/src/server/ai/aiReviewParse.ts
@@ -1,0 +1,49 @@
+import 'server-only';
+
+import { z } from 'zod';
+
+import type { AiReviewSectionNote, AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
+import { AI_REVIEW_DISCLAIMERS } from '@/server/ai/aiReviewTypes';
+
+const LlmJsonSchema = z.object({
+  summary: z.string().min(1),
+  sectionNotes: z
+    .array(
+      z.object({
+        sectionId: z.string(),
+        severity: z.enum(['info', 'warning', 'danger']),
+        message: z.string(),
+        suggestedAction: z.enum(['review_manually', 'safe_to_proceed', 'do_not_full_replace', 'check_counts']),
+      }),
+    )
+    .optional(),
+});
+
+export function parseLlmJsonContent(raw: string): { summary: string; sectionNotes?: AiReviewSectionNote[] } | null {
+  const trimmed = raw.trim();
+  const jsonText = trimmed.startsWith('```')
+    ? trimmed.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '')
+    : trimmed;
+  try {
+    const parsed = LlmJsonSchema.parse(JSON.parse(jsonText));
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function advisoryErrorResult(
+  partial: Pick<AiReviewSuggestionResult, 'provider' | 'model' | 'inputHash' | 'status' | 'error'>,
+): AiReviewSuggestionResult {
+  return {
+    advisory: true,
+    enabled: partial.status !== 'disabled',
+    provider: partial.provider,
+    model: partial.model,
+    status: partial.status,
+    generatedAt: new Date().toISOString(),
+    inputHash: partial.inputHash,
+    disclaimers: [...AI_REVIEW_DISCLAIMERS],
+    error: partial.error,
+  };
+}

--- a/src/server/ai/aiReviewPrompt.ts
+++ b/src/server/ai/aiReviewPrompt.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+
+import type { AiReviewInput } from '@/server/ai/aiReviewTypes';
+
+export const AI_REVIEW_SYSTEM_PROMPT = `You are an advisory review assistant for a DOCX CV import into a professor website admin workflow.
+
+Rules:
+- You do NOT decide merge or publish.
+- You do NOT rewrite final public website content.
+- You do NOT invent missing facts.
+- Use ONLY the minimized review context provided in the user message.
+- Return JSON only (no markdown fences).
+- Do NOT output private contact data (emails, phones, URLs).
+- Focus on parser risk, count mismatches, suspicious changes, unmapped sections, and manual review advice.
+- Do NOT say "safe to publish"; at most say "review appears lower risk" when appropriate.
+- Do NOT advise bypassing safe_update defaults or full_replace acknowledgement.
+- Do NOT recommend auto-merge or auto-publish.
+
+Output JSON schema:
+{
+  "summary": "string (1-3 sentences)",
+  "sectionNotes": [
+    {
+      "sectionId": "string (matches merge safety or review block id when possible)",
+      "severity": "info" | "warning" | "danger",
+      "message": "string",
+      "suggestedAction": "review_manually" | "safe_to_proceed" | "do_not_full_replace" | "check_counts"
+    }
+  ]
+}`;
+
+export function buildAiReviewUserPrompt(input: AiReviewInput): string {
+  return JSON.stringify(input);
+}

--- a/src/server/ai/aiReviewRateLimit.ts
+++ b/src/server/ai/aiReviewRateLimit.ts
@@ -4,7 +4,16 @@ import crypto from 'node:crypto';
 
 type Entry = { count: number; resetTime: number };
 
+/** Best-effort in-memory buckets; not shared across serverless instances or cold starts. */
 const buckets = new Map<string, Entry>();
+
+function pruneExpiredBuckets(now: number): void {
+  for (const [key, entry] of buckets) {
+    if (now > entry.resetTime) {
+      buckets.delete(key);
+    }
+  }
+}
 
 export function aiReviewRateLimitKey(sessionCookie: string | undefined): string {
   if (!sessionCookie) {
@@ -19,6 +28,7 @@ export function checkAiReviewRateLimit(
 ): { allowed: boolean; remaining: number; resetTime: number } {
   const now = Date.now();
   const windowMs = 60 * 60 * 1000;
+  pruneExpiredBuckets(now);
   const entry = buckets.get(key);
 
   if (!entry || now > entry.resetTime) {
@@ -33,4 +43,15 @@ export function checkAiReviewRateLimit(
 
   entry.count += 1;
   return { allowed: true, remaining: maxPerHour - entry.count, resetTime: entry.resetTime };
+}
+
+/** Test-only: clear in-memory buckets. */
+export function resetAiReviewRateLimitsForTests(): void {
+  buckets.clear();
+}
+
+/** Test-only: inspect bucket count after pruning. */
+export function aiReviewRateLimitBucketCountForTests(): number {
+  pruneExpiredBuckets(Date.now());
+  return buckets.size;
 }

--- a/src/server/ai/aiReviewRateLimit.ts
+++ b/src/server/ai/aiReviewRateLimit.ts
@@ -1,0 +1,36 @@
+import 'server-only';
+
+import crypto from 'node:crypto';
+
+type Entry = { count: number; resetTime: number };
+
+const buckets = new Map<string, Entry>();
+
+export function aiReviewRateLimitKey(sessionCookie: string | undefined): string {
+  if (!sessionCookie) {
+    return 'anonymous';
+  }
+  return crypto.createHash('sha256').update(sessionCookie).digest('hex').slice(0, 16);
+}
+
+export function checkAiReviewRateLimit(
+  key: string,
+  maxPerHour: number,
+): { allowed: boolean; remaining: number; resetTime: number } {
+  const now = Date.now();
+  const windowMs = 60 * 60 * 1000;
+  const entry = buckets.get(key);
+
+  if (!entry || now > entry.resetTime) {
+    const resetTime = now + windowMs;
+    buckets.set(key, { count: 1, resetTime });
+    return { allowed: true, remaining: maxPerHour - 1, resetTime };
+  }
+
+  if (entry.count >= maxPerHour) {
+    return { allowed: false, remaining: 0, resetTime: entry.resetTime };
+  }
+
+  entry.count += 1;
+  return { allowed: true, remaining: maxPerHour - entry.count, resetTime: entry.resetTime };
+}

--- a/src/server/ai/aiReviewRedact.ts
+++ b/src/server/ai/aiReviewRedact.ts
@@ -1,0 +1,12 @@
+import 'server-only';
+
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+const URL_RE = /https?:\/\/[^\s<>"\]]+/gi;
+const PHONE_RE = /(?:\+?\d{1,3}[-.\s]?)?\(?\d{1,4}\)?[-.\s]?\d{1,4}[-.\s]?\d{1,9}/g;
+
+export function redactSensitiveText(text: string): string {
+  return text
+    .replace(EMAIL_RE, '[redacted-email]')
+    .replace(URL_RE, '[redacted-url]')
+    .replace(PHONE_RE, (m) => (m.replace(/\D/g, '').length >= 7 ? '[redacted-phone]' : m));
+}

--- a/src/server/ai/aiReviewRedact.ts
+++ b/src/server/ai/aiReviewRedact.ts
@@ -4,9 +4,46 @@ const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 const URL_RE = /https?:\/\/[^\s<>"\]]+/gi;
 const PHONE_RE = /(?:\+?\d{1,3}[-.\s]?)?\(?\d{1,4}\)?[-.\s]?\d{1,4}[-.\s]?\d{1,9}/g;
 
+const DAY = '(?:0[1-9]|[12]\\d|3[01])';
+const MONTH = '(?:0[1-9]|1[0-2])';
+const YEAR = '(?:19|20)\\d{2}';
+
+const ISO_DATE_RE = new RegExp(`\\b${YEAR}[-/.]${MONTH}[-/.]${DAY}\\b`, 'g');
+const DMY_DATE_RE = new RegExp(`\\b${DAY}[-/.]${MONTH}[-/.]${YEAR}\\b`, 'g');
+const YEAR_RANGE_RE = /\b(19|20)\d{2}\s*-\s*(19|20)\d{2}\b/g;
+
+const DATE_TOKEN_PREFIX = '\x00DATE';
+const DATE_TOKEN_SUFFIX = '\x00';
+
+function protectPattern(text: string, re: RegExp, tokens: string[]): string {
+  return text.replace(re, (match) => {
+    const idx = tokens.length;
+    tokens.push(match);
+    return `${DATE_TOKEN_PREFIX}${idx}${DATE_TOKEN_SUFFIX}`;
+  });
+}
+
+function restoreProtected(text: string, tokens: string[]): string {
+  return text.replace(
+    new RegExp(`${DATE_TOKEN_PREFIX}(\\d+)${DATE_TOKEN_SUFFIX}`, 'g'),
+    (_m, idx) => tokens[Number(idx)] ?? _m,
+  );
+}
+
+function protectDatesAndYearRanges(text: string): { text: string; tokens: string[] } {
+  const tokens: string[] = [];
+  let out = text;
+  out = protectPattern(out, YEAR_RANGE_RE, tokens);
+  out = protectPattern(out, ISO_DATE_RE, tokens);
+  out = protectPattern(out, DMY_DATE_RE, tokens);
+  return { text: out, tokens };
+}
+
 export function redactSensitiveText(text: string): string {
-  return text
+  const { text: protectedText, tokens } = protectDatesAndYearRanges(text);
+  const redacted = protectedText
     .replace(EMAIL_RE, '[redacted-email]')
     .replace(URL_RE, '[redacted-url]')
     .replace(PHONE_RE, (m) => (m.replace(/\D/g, '').length >= 7 ? '[redacted-phone]' : m));
+  return restoreProtected(redacted, tokens);
 }

--- a/src/server/ai/aiReviewTypes.ts
+++ b/src/server/ai/aiReviewTypes.ts
@@ -1,0 +1,104 @@
+import 'server-only';
+
+export type AiProviderId = 'none' | 'ollama' | 'openrouter' | 'groq' | 'openai';
+
+export type AiReviewStatus = 'ok' | 'disabled' | 'error' | 'timeout' | 'misconfigured';
+
+export type AiReviewSuggestedAction =
+  | 'review_manually'
+  | 'safe_to_proceed'
+  | 'do_not_full_replace'
+  | 'check_counts';
+
+export type AiReviewSectionNote = {
+  sectionId: string;
+  severity: 'info' | 'warning' | 'danger';
+  message: string;
+  suggestedAction: AiReviewSuggestedAction;
+};
+
+export type AiReviewInput = {
+  importId: string;
+  importStatus: string;
+  parserVersion: string | null;
+  mappingVersion: string | null;
+  baselineSource: string;
+  baselineLabel: string;
+  reviewHint: string | null;
+  countValidation: Array<{
+    code: string;
+    domain: string;
+    severity: string;
+    declaredInHeading: number | null;
+    extractedCount: number;
+  }>;
+  parserWarnings: Array<{ code?: string; message: string; severity: string }>;
+  unmappedSections: Array<{ sectionId: string; title: string; reason: string }>;
+  mergeSafety: {
+    fullReplaceRequiresAck: boolean;
+    sections: Array<{
+      id: string;
+      title: string;
+      risk: string;
+      includeInSafeMerge: boolean;
+      reasons: string[];
+    }>;
+    notes: string[];
+  };
+  reviewWarnings: Array<{ message: string; code?: string }>;
+  blockSummaries: Array<{
+    id: string;
+    title: string;
+    addedCount: number;
+    removedCount: number;
+    changedCount: number;
+    sampleLines?: string[];
+  }>;
+};
+
+export type AiReviewSuggestionResult = {
+  advisory: true;
+  enabled: boolean;
+  provider: AiProviderId;
+  model?: string;
+  status: AiReviewStatus;
+  generatedAt: string;
+  inputHash: string;
+  summary?: string;
+  sectionNotes?: AiReviewSectionNote[];
+  disclaimers: string[];
+  error?: string;
+};
+
+export type AiProviderStatus = 'disabled' | 'configured' | 'misconfigured' | 'unavailable';
+
+export type AiProviderOptionView = {
+  id: AiProviderId;
+  label: string;
+  status: AiProviderStatus;
+  active: boolean;
+  model: string | null;
+  allowedModels: string[];
+  statusMessage: string;
+  hostedNote?: string;
+};
+
+export type AiProviderSettingsView = {
+  activeProvider: AiProviderId;
+  activeModel: string | null;
+  switchingMode: 'env_only';
+  switchingNote: string;
+  providers: AiProviderOptionView[];
+  disclaimers: string[];
+};
+
+export interface AiReviewProvider {
+  readonly id: AiProviderId;
+  generateSuggestions(input: AiReviewInput, inputHash: string): Promise<AiReviewSuggestionResult>;
+}
+
+export const AI_REVIEW_DISCLAIMERS = [
+  'AI suggestions are advisory, may be wrong, and never change drafts, merge behavior, or the public site.',
+  'AI does not decide merge or publish. Follow parser warnings and merge safety tables.',
+  'External providers receive minimized review context only - not DOCX files or full raw document text.',
+] as const;

--- a/src/server/ai/buildAiReviewInput.ts
+++ b/src/server/ai/buildAiReviewInput.ts
@@ -1,0 +1,217 @@
+import 'server-only';
+
+import crypto from 'node:crypto';
+
+import { getAiReviewRuntimeConfig } from '@/server/ai/aiReviewConfig';
+import { redactSensitiveText } from '@/server/ai/aiReviewRedact';
+import type { AiReviewInput } from '@/server/ai/aiReviewTypes';
+import { buildImportReviewPayload } from '@/server/imports/importReviewCompare';
+import type { ImportReviewBlock } from '@/server/imports/importReviewStructured';
+import { getContentImportDetail } from '@/server/imports/repository';
+import type { ReviewBaselineMode } from '@/server/imports/reviewBaseline';
+import { buildImportCandidateReviewMetadata } from '@/server/imports/serialize';
+
+const RISKY_RISKS = new Set(['needs_review', 'review_only_default', 'requires_explicit_replace']);
+const MAX_SAMPLE_LINES = 2;
+const MAX_SAMPLE_LINE_CHARS = 200;
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+export function hashAiReviewInput(input: AiReviewInput): string {
+  return crypto.createHash('sha256').update(stableStringify(input)).digest('hex');
+}
+
+function sampleLinesFromBlock(block: ImportReviewBlock, risky: boolean): string[] | undefined {
+  if (!risky) {
+    return undefined;
+  }
+  const lines: string[] = [];
+  for (const item of block.changed) {
+    for (const ln of item.lines) {
+      if (lines.length >= MAX_SAMPLE_LINES) {
+        break;
+      }
+      const redacted = redactSensitiveText(ln);
+      lines.push(redacted.length > MAX_SAMPLE_LINE_CHARS ? `${redacted.slice(0, MAX_SAMPLE_LINE_CHARS)}...` : redacted);
+    }
+  }
+  if (lines.length < MAX_SAMPLE_LINES) {
+    for (const ln of block.added) {
+      if (lines.length >= MAX_SAMPLE_LINES) {
+        break;
+      }
+      const redacted = redactSensitiveText(ln);
+      lines.push(redacted.length > MAX_SAMPLE_LINE_CHARS ? `${redacted.slice(0, MAX_SAMPLE_LINE_CHARS)}...` : redacted);
+    }
+  }
+  return lines.length > 0 ? lines : undefined;
+}
+
+function trimInputToCap(input: AiReviewInput, maxChars: number): AiReviewInput {
+  let current: AiReviewInput = input;
+  if (stableStringify(current).length <= maxChars) {
+    return current;
+  }
+
+  current = {
+    ...current,
+    blockSummaries: current.blockSummaries.map((b) => ({ ...b, sampleLines: undefined })),
+  };
+  if (stableStringify(current).length <= maxChars) {
+    return current;
+  }
+
+  current = {
+    ...current,
+    blockSummaries: current.blockSummaries.filter((b) =>
+      current.mergeSafety.sections.some((s) => s.id === b.id && RISKY_RISKS.has(s.risk)),
+    ),
+  };
+  if (stableStringify(current).length <= maxChars) {
+    return current;
+  }
+
+  while (current.blockSummaries.length > 0 && stableStringify(current).length > maxChars) {
+    current = { ...current, blockSummaries: current.blockSummaries.slice(0, -1) };
+  }
+  if (stableStringify(current).length <= maxChars) {
+    return current;
+  }
+
+  current = { ...current, blockSummaries: [] };
+  if (stableStringify(current).length <= maxChars) {
+    return current;
+  }
+
+  current = {
+    ...current,
+    mergeSafety: {
+      ...current.mergeSafety,
+      sections: current.mergeSafety.sections.map((s) => ({
+        ...s,
+        reasons: s.reasons.slice(0, 2).map((r) => (r.length > 120 ? `${r.slice(0, 120)}...` : r)),
+      })),
+      notes: current.mergeSafety.notes.slice(0, 3),
+    },
+    parserWarnings: current.parserWarnings.slice(0, 10),
+    reviewWarnings: current.reviewWarnings.slice(0, 10),
+    unmappedSections: current.unmappedSections.slice(0, 5),
+    countValidation: current.countValidation.slice(0, 10),
+  };
+  if (stableStringify(current).length <= maxChars) {
+    return current;
+  }
+
+  current = {
+    ...current,
+    unmappedSections: [],
+    countValidation: current.countValidation.slice(0, 3),
+    mergeSafety: {
+      ...current.mergeSafety,
+      sections: current.mergeSafety.sections
+        .filter((s) => RISKY_RISKS.has(s.risk))
+        .map((s) => ({ ...s, reasons: s.reasons.slice(0, 1) })),
+      notes: current.mergeSafety.notes.slice(0, 1),
+    },
+    parserWarnings: current.parserWarnings.slice(0, 5),
+    reviewWarnings: current.reviewWarnings.slice(0, 5),
+  };
+  if (stableStringify(current).length <= maxChars) {
+    return current;
+  }
+
+  return {
+    ...current,
+    blockSummaries: [],
+    unmappedSections: [],
+    countValidation: [],
+    reviewWarnings: current.reviewWarnings.slice(0, 3),
+    parserWarnings: current.parserWarnings.slice(0, 3),
+    mergeSafety: {
+      fullReplaceRequiresAck: current.mergeSafety.fullReplaceRequiresAck,
+      sections: current.mergeSafety.sections.slice(0, 8).map((s) => ({
+        id: s.id,
+        title: s.title,
+        risk: s.risk,
+        includeInSafeMerge: s.includeInSafeMerge,
+        reasons: s.reasons.slice(0, 1).map((r) => (r.length > 80 ? `${r.slice(0, 80)}...` : r)),
+      })),
+      notes: [],
+    },
+  };
+}
+
+export async function buildAiReviewInput(
+  importId: string,
+  baseline: ReviewBaselineMode,
+): Promise<{ input: AiReviewInput; inputHash: string } | null> {
+  const row = await getContentImportDetail(importId);
+  if (!row) {
+    return null;
+  }
+
+  const review = await buildImportReviewPayload(importId, { baseline });
+  const candidateReview = buildImportCandidateReviewMetadata(row.candidatePayload);
+  const riskySectionIds = new Set(
+    review.mergeSafety.sections.filter((s) => RISKY_RISKS.has(s.risk)).map((s) => s.id),
+  );
+
+  const input: AiReviewInput = {
+    importId: row.id,
+    importStatus: row.status,
+    parserVersion: candidateReview?.parserVersion ?? row.parserVersion,
+    mappingVersion: candidateReview?.mappingVersion ?? null,
+    baselineSource: review.baselineSource,
+    baselineLabel: review.baselineLabel,
+    reviewHint: candidateReview?.reviewHint ?? null,
+    countValidation:
+      candidateReview?.countValidation.entries.map((e) => ({
+        code: e.code,
+        domain: e.domain,
+        severity: e.severity,
+        declaredInHeading: e.declaredInHeading,
+        extractedCount: e.extractedCount,
+      })) ?? [],
+    parserWarnings:
+      candidateReview?.parserWarnings.map((w) => ({
+        code: w.code,
+        message: redactSensitiveText(w.message),
+        severity: w.severity,
+      })) ?? [],
+    unmappedSections:
+      candidateReview?.unmappedSections.map((u) => ({
+        sectionId: u.sectionId,
+        title: u.title,
+        reason: redactSensitiveText(u.reason),
+      })) ?? [],
+    mergeSafety: {
+      fullReplaceRequiresAck: review.mergeSafety.fullReplaceRequiresAck,
+      sections: review.mergeSafety.sections.map((s) => ({
+        id: s.id,
+        title: s.title,
+        risk: s.risk,
+        includeInSafeMerge: s.includeInSafeMerge,
+        reasons: s.reasons.map((r) => redactSensitiveText(r)),
+      })),
+      notes: review.mergeSafety.notes.map((n) => redactSensitiveText(n)),
+    },
+    reviewWarnings: review.warnings.map((w) => ({
+      code: w.code,
+      message: redactSensitiveText(w.message),
+    })),
+    blockSummaries: review.blocks.map((b) => ({
+      id: b.id,
+      title: b.title,
+      addedCount: b.added.length,
+      removedCount: b.removed.length,
+      changedCount: b.changed.length,
+      sampleLines: sampleLinesFromBlock(b, riskySectionIds.has(b.id)),
+    })),
+  };
+
+  const { maxInputChars } = getAiReviewRuntimeConfig();
+  const capped = trimInputToCap(input, maxInputChars);
+  return { input: capped, inputHash: hashAiReviewInput(capped) };
+}

--- a/src/server/ai/buildAiReviewInput.ts
+++ b/src/server/ai/buildAiReviewInput.ts
@@ -49,6 +49,35 @@ function sampleLinesFromBlock(block: ImportReviewBlock, risky: boolean): string[
   return lines.length > 0 ? lines : undefined;
 }
 
+function fitBlockSummaries(
+  input: AiReviewInput,
+  blockSummaries: AiReviewInput['blockSummaries'],
+  count: number,
+): AiReviewInput {
+  return { ...input, blockSummaries: blockSummaries.slice(0, count) };
+}
+
+function binarySearchBlockFit(
+  input: AiReviewInput,
+  blockSummaries: AiReviewInput['blockSummaries'],
+  maxChars: number,
+): AiReviewInput {
+  let lo = 0;
+  let hi = blockSummaries.length;
+  let best = fitBlockSummaries(input, blockSummaries, 0);
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const candidate = fitBlockSummaries(input, blockSummaries, mid);
+    if (stableStringify(candidate).length <= maxChars) {
+      best = candidate;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}
+
 function trimInputToCap(input: AiReviewInput, maxChars: number): AiReviewInput {
   let current: AiReviewInput = input;
   if (stableStringify(current).length <= maxChars) {
@@ -63,19 +92,10 @@ function trimInputToCap(input: AiReviewInput, maxChars: number): AiReviewInput {
     return current;
   }
 
-  current = {
-    ...current,
-    blockSummaries: current.blockSummaries.filter((b) =>
-      current.mergeSafety.sections.some((s) => s.id === b.id && RISKY_RISKS.has(s.risk)),
-    ),
-  };
-  if (stableStringify(current).length <= maxChars) {
-    return current;
-  }
-
-  while (current.blockSummaries.length > 0 && stableStringify(current).length > maxChars) {
-    current = { ...current, blockSummaries: current.blockSummaries.slice(0, -1) };
-  }
+  const riskyBlocks = current.blockSummaries.filter((b) =>
+    current.mergeSafety.sections.some((s) => s.id === b.id && RISKY_RISKS.has(s.risk)),
+  );
+  current = binarySearchBlockFit(current, riskyBlocks, maxChars);
   if (stableStringify(current).length <= maxChars) {
     return current;
   }
@@ -167,7 +187,7 @@ export async function buildAiReviewInput(
     baselineLabel: review.baselineLabel,
     reviewHint: candidateReview?.reviewHint ?? null,
     countValidation:
-      candidateReview?.countValidation.entries.map((e) => ({
+      candidateReview?.countValidation?.entries?.map((e) => ({
         code: e.code,
         domain: e.domain,
         severity: e.severity,
@@ -175,13 +195,13 @@ export async function buildAiReviewInput(
         extractedCount: e.extractedCount,
       })) ?? [],
     parserWarnings:
-      candidateReview?.parserWarnings.map((w) => ({
+      candidateReview?.parserWarnings?.map((w) => ({
         code: w.code,
         message: redactSensitiveText(w.message),
         severity: w.severity,
       })) ?? [],
     unmappedSections:
-      candidateReview?.unmappedSections.map((u) => ({
+      candidateReview?.unmappedSections?.map((u) => ({
         sectionId: u.sectionId,
         title: u.title,
         reason: redactSensitiveText(u.reason),

--- a/src/server/ai/providerRegistry.ts
+++ b/src/server/ai/providerRegistry.ts
@@ -1,0 +1,20 @@
+import 'server-only';
+
+import type { AiProviderId, AiReviewProvider } from '@/server/ai/aiReviewTypes';
+import { groqAiReviewProvider } from '@/server/ai/providers/groqProvider';
+import { noneAiReviewProvider } from '@/server/ai/providers/noneProvider';
+import { ollamaAiReviewProvider } from '@/server/ai/providers/ollamaProvider';
+import { openAiAiReviewProvider } from '@/server/ai/providers/openAiProvider';
+import { openRouterAiReviewProvider } from '@/server/ai/providers/openRouterProvider';
+
+const PROVIDERS: Record<AiProviderId, AiReviewProvider> = {
+  none: noneAiReviewProvider,
+  ollama: ollamaAiReviewProvider,
+  openrouter: openRouterAiReviewProvider,
+  groq: groqAiReviewProvider,
+  openai: openAiAiReviewProvider,
+};
+
+export function getAiReviewProvider(id: AiProviderId): AiReviewProvider {
+  return PROVIDERS[id] ?? noneAiReviewProvider;
+}

--- a/src/server/ai/providers/groqProvider.ts
+++ b/src/server/ai/providers/groqProvider.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import { getAiReviewRuntimeConfig } from '@/server/ai/aiReviewConfig';
+import { openAiCompatibleChat } from '@/server/ai/aiReviewFetch';
+import type { AiReviewProvider } from '@/server/ai/aiReviewTypes';
+import { misconfiguredResult, resolveProviderModel, runLlmAiReview } from '@/server/ai/providers/llmProviderShared';
+
+export const groqAiReviewProvider: AiReviewProvider = {
+  id: 'groq',
+  async generateSuggestions(input, inputHash) {
+    const cfg = getAiReviewRuntimeConfig();
+    if (!cfg.groq.apiKey) {
+      return misconfiguredResult('groq', inputHash, 'GROQ_API_KEY is not set');
+    }
+    const modelOrErr = resolveProviderModel('groq', cfg.groq.model, cfg.groq.allowedModels, inputHash);
+    if (typeof modelOrErr !== 'string') {
+      return modelOrErr;
+    }
+    return runLlmAiReview({
+      provider: 'groq',
+      model: modelOrErr,
+      input,
+      inputHash,
+      call: (messages) =>
+        openAiCompatibleChat({
+          url: 'https://api.groq.com/openai/v1/chat/completions',
+          apiKey: cfg.groq.apiKey!,
+          model: modelOrErr,
+          messages,
+          timeoutMs: cfg.timeoutMs,
+          responseFormatJson: true,
+        }),
+    });
+  },
+};

--- a/src/server/ai/providers/llmProviderShared.ts
+++ b/src/server/ai/providers/llmProviderShared.ts
@@ -6,6 +6,18 @@ import { AI_REVIEW_SYSTEM_PROMPT, buildAiReviewUserPrompt } from '@/server/ai/ai
 import type { AiProviderId, AiReviewInput, AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
 import { AI_REVIEW_DISCLAIMERS } from '@/server/ai/aiReviewTypes';
 
+export function isAiProviderTimeoutError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+  if (error instanceof Error) {
+    const msg = error.message.toLowerCase();
+    return msg.includes('abort') || msg.includes('timeout');
+  }
+  const msg = String(error).toLowerCase();
+  return msg.includes('abort') || msg.includes('timeout');
+}
+
 export async function runLlmAiReview(opts: {
   provider: AiProviderId;
   model: string;
@@ -42,12 +54,11 @@ export async function runLlmAiReview(opts: {
     };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    const isTimeout = msg.includes('abort') || msg.toLowerCase().includes('timeout');
     return advisoryErrorResult({
       provider: opts.provider,
       model: opts.model,
       inputHash: opts.inputHash,
-      status: isTimeout ? 'timeout' : 'error',
+      status: isAiProviderTimeoutError(e) ? 'timeout' : 'error',
       error: msg,
     });
   }

--- a/src/server/ai/providers/llmProviderShared.ts
+++ b/src/server/ai/providers/llmProviderShared.ts
@@ -1,0 +1,75 @@
+import 'server-only';
+
+import { resolveAllowlistedModel } from '@/server/ai/aiReviewConfig';
+import { advisoryErrorResult, parseLlmJsonContent } from '@/server/ai/aiReviewParse';
+import { AI_REVIEW_SYSTEM_PROMPT, buildAiReviewUserPrompt } from '@/server/ai/aiReviewPrompt';
+import type { AiProviderId, AiReviewInput, AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
+import { AI_REVIEW_DISCLAIMERS } from '@/server/ai/aiReviewTypes';
+
+export async function runLlmAiReview(opts: {
+  provider: AiProviderId;
+  model: string;
+  input: AiReviewInput;
+  inputHash: string;
+  call: (messages: { role: 'system' | 'user'; content: string }[]) => Promise<string>;
+}): Promise<AiReviewSuggestionResult> {
+  try {
+    const content = await opts.call([
+      { role: 'system', content: AI_REVIEW_SYSTEM_PROMPT },
+      { role: 'user', content: buildAiReviewUserPrompt(opts.input) },
+    ]);
+    const parsed = parseLlmJsonContent(content);
+    if (!parsed) {
+      return advisoryErrorResult({
+        provider: opts.provider,
+        model: opts.model,
+        inputHash: opts.inputHash,
+        status: 'error',
+        error: 'Provider returned malformed JSON',
+      });
+    }
+    return {
+      advisory: true,
+      enabled: true,
+      provider: opts.provider,
+      model: opts.model,
+      status: 'ok',
+      generatedAt: new Date().toISOString(),
+      inputHash: opts.inputHash,
+      summary: parsed.summary,
+      sectionNotes: parsed.sectionNotes,
+      disclaimers: [...AI_REVIEW_DISCLAIMERS],
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const isTimeout = msg.includes('abort') || msg.toLowerCase().includes('timeout');
+    return advisoryErrorResult({
+      provider: opts.provider,
+      model: opts.model,
+      inputHash: opts.inputHash,
+      status: isTimeout ? 'timeout' : 'error',
+      error: msg,
+    });
+  }
+}
+
+export function misconfiguredResult(
+  provider: AiProviderId,
+  inputHash: string,
+  error: string,
+): AiReviewSuggestionResult {
+  return advisoryErrorResult({ provider, inputHash, status: 'misconfigured', error });
+}
+
+export function resolveProviderModel(
+  provider: AiProviderId,
+  model: string,
+  allowed: string[],
+  inputHash: string,
+): string | AiReviewSuggestionResult {
+  const resolved = resolveAllowlistedModel(model, allowed);
+  if (!resolved) {
+    return misconfiguredResult(provider, inputHash, `Model not in allowlist for ${provider}`);
+  }
+  return resolved;
+}

--- a/src/server/ai/providers/noneProvider.ts
+++ b/src/server/ai/providers/noneProvider.ts
@@ -1,0 +1,20 @@
+import 'server-only';
+
+import type { AiReviewProvider, AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
+import { AI_REVIEW_DISCLAIMERS } from '@/server/ai/aiReviewTypes';
+
+export const noneAiReviewProvider: AiReviewProvider = {
+  id: 'none',
+  async generateSuggestions(_input, inputHash): Promise<AiReviewSuggestionResult> {
+    return {
+      advisory: true,
+      enabled: false,
+      provider: 'none',
+      status: 'disabled',
+      generatedAt: new Date().toISOString(),
+      inputHash,
+      disclaimers: [...AI_REVIEW_DISCLAIMERS],
+      error: 'AI_PROVIDER is none. Set AI_PROVIDER and provider credentials to enable suggestions.',
+    };
+  },
+};

--- a/src/server/ai/providers/ollamaProvider.ts
+++ b/src/server/ai/providers/ollamaProvider.ts
@@ -1,0 +1,90 @@
+import 'server-only';
+
+import { getAiReviewRuntimeConfig } from '@/server/ai/aiReviewConfig';
+import { fetchWithTimeout } from '@/server/ai/aiReviewFetch';
+import { advisoryErrorResult, parseLlmJsonContent } from '@/server/ai/aiReviewParse';
+import { AI_REVIEW_SYSTEM_PROMPT, buildAiReviewUserPrompt } from '@/server/ai/aiReviewPrompt';
+import type { AiReviewProvider, AiReviewInput, AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
+import { AI_REVIEW_DISCLAIMERS } from '@/server/ai/aiReviewTypes';
+import { misconfiguredResult, resolveProviderModel } from '@/server/ai/providers/llmProviderShared';
+
+async function ollamaChat(baseUrl: string, model: string, input: AiReviewInput, timeoutMs: number): Promise<string> {
+  const res = await fetchWithTimeout(
+    `${baseUrl}/api/chat`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        stream: false,
+        format: 'json',
+        messages: [
+          { role: 'system', content: AI_REVIEW_SYSTEM_PROMPT },
+          { role: 'user', content: buildAiReviewUserPrompt(input) },
+        ],
+      }),
+    },
+    timeoutMs,
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Ollama HTTP ${res.status}: ${text.slice(0, 300)}`);
+  }
+  const data = (await res.json()) as { message?: { content?: string } };
+  const content = data.message?.content;
+  if (!content) {
+    throw new Error('Ollama returned empty response');
+  }
+  return content;
+}
+
+export const ollamaAiReviewProvider: AiReviewProvider = {
+  id: 'ollama',
+  async generateSuggestions(input, inputHash): Promise<AiReviewSuggestionResult> {
+    const cfg = getAiReviewRuntimeConfig();
+    const modelOrErr = resolveProviderModel('ollama', cfg.ollama.model, cfg.ollama.allowedModels, inputHash);
+    if (typeof modelOrErr !== 'string') {
+      return modelOrErr;
+    }
+
+    try {
+      const content = await ollamaChat(cfg.ollama.baseUrl, modelOrErr, input, cfg.timeoutMs);
+      const parsed = parseLlmJsonContent(content);
+      if (!parsed) {
+        return advisoryErrorResult({
+          provider: 'ollama',
+          model: modelOrErr,
+          inputHash,
+          status: 'error',
+          error: 'Ollama returned malformed JSON',
+        });
+      }
+      return {
+        advisory: true,
+        enabled: true,
+        provider: 'ollama',
+        model: modelOrErr,
+        status: 'ok',
+        generatedAt: new Date().toISOString(),
+        inputHash,
+        summary: parsed.summary,
+        sectionNotes: parsed.sectionNotes,
+        disclaimers: [...AI_REVIEW_DISCLAIMERS],
+      };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const isTimeout = msg.includes('abort');
+      return advisoryErrorResult({
+        provider: 'ollama',
+        model: modelOrErr,
+        inputHash,
+        status: isTimeout ? 'timeout' : 'error',
+        error: msg,
+      });
+    }
+  },
+};
+
+export function ollamaProviderMisconfigured(inputHash: string): AiReviewSuggestionResult {
+  return misconfiguredResult('ollama', inputHash, 'Ollama is selected but not reachable or misconfigured');
+}

--- a/src/server/ai/providers/ollamaProvider.ts
+++ b/src/server/ai/providers/ollamaProvider.ts
@@ -1,15 +1,17 @@
 import 'server-only';
 
 import { getAiReviewRuntimeConfig } from '@/server/ai/aiReviewConfig';
-import { fetchWithTimeout } from '@/server/ai/aiReviewFetch';
-import { advisoryErrorResult, parseLlmJsonContent } from '@/server/ai/aiReviewParse';
-import { AI_REVIEW_SYSTEM_PROMPT, buildAiReviewUserPrompt } from '@/server/ai/aiReviewPrompt';
-import type { AiReviewProvider, AiReviewInput, AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
-import { AI_REVIEW_DISCLAIMERS } from '@/server/ai/aiReviewTypes';
-import { misconfiguredResult, resolveProviderModel } from '@/server/ai/providers/llmProviderShared';
+import { fetchWithTimeout, type ChatMessage } from '@/server/ai/aiReviewFetch';
+import type { AiReviewProvider, AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
+import { misconfiguredResult, resolveProviderModel, runLlmAiReview } from '@/server/ai/providers/llmProviderShared';
 
-async function ollamaChat(baseUrl: string, model: string, input: AiReviewInput, timeoutMs: number): Promise<string> {
-  const res = await fetchWithTimeout(
+async function ollamaChat(
+  baseUrl: string,
+  model: string,
+  messages: ChatMessage[],
+  timeoutMs: number,
+): Promise<string> {
+  return fetchWithTimeout(
     `${baseUrl}/api/chat`,
     {
       method: 'POST',
@@ -18,24 +20,23 @@ async function ollamaChat(baseUrl: string, model: string, input: AiReviewInput, 
         model,
         stream: false,
         format: 'json',
-        messages: [
-          { role: 'system', content: AI_REVIEW_SYSTEM_PROMPT },
-          { role: 'user', content: buildAiReviewUserPrompt(input) },
-        ],
+        messages,
       }),
     },
     timeoutMs,
+    async (res) => {
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`Ollama HTTP ${res.status}: ${text.slice(0, 300)}`);
+      }
+      const data = (await res.json()) as { message?: { content?: string } };
+      const content = data.message?.content;
+      if (!content) {
+        throw new Error('Ollama returned empty response');
+      }
+      return content;
+    },
   );
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Ollama HTTP ${res.status}: ${text.slice(0, 300)}`);
-  }
-  const data = (await res.json()) as { message?: { content?: string } };
-  const content = data.message?.content;
-  if (!content) {
-    throw new Error('Ollama returned empty response');
-  }
-  return content;
 }
 
 export const ollamaAiReviewProvider: AiReviewProvider = {
@@ -47,41 +48,13 @@ export const ollamaAiReviewProvider: AiReviewProvider = {
       return modelOrErr;
     }
 
-    try {
-      const content = await ollamaChat(cfg.ollama.baseUrl, modelOrErr, input, cfg.timeoutMs);
-      const parsed = parseLlmJsonContent(content);
-      if (!parsed) {
-        return advisoryErrorResult({
-          provider: 'ollama',
-          model: modelOrErr,
-          inputHash,
-          status: 'error',
-          error: 'Ollama returned malformed JSON',
-        });
-      }
-      return {
-        advisory: true,
-        enabled: true,
-        provider: 'ollama',
-        model: modelOrErr,
-        status: 'ok',
-        generatedAt: new Date().toISOString(),
-        inputHash,
-        summary: parsed.summary,
-        sectionNotes: parsed.sectionNotes,
-        disclaimers: [...AI_REVIEW_DISCLAIMERS],
-      };
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      const isTimeout = msg.includes('abort');
-      return advisoryErrorResult({
-        provider: 'ollama',
-        model: modelOrErr,
-        inputHash,
-        status: isTimeout ? 'timeout' : 'error',
-        error: msg,
-      });
-    }
+    return runLlmAiReview({
+      provider: 'ollama',
+      model: modelOrErr,
+      input,
+      inputHash,
+      call: (messages) => ollamaChat(cfg.ollama.baseUrl, modelOrErr, messages, cfg.timeoutMs),
+    });
   },
 };
 

--- a/src/server/ai/providers/openAiProvider.ts
+++ b/src/server/ai/providers/openAiProvider.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import { getAiReviewRuntimeConfig } from '@/server/ai/aiReviewConfig';
+import { openAiCompatibleChat } from '@/server/ai/aiReviewFetch';
+import type { AiReviewProvider } from '@/server/ai/aiReviewTypes';
+import { misconfiguredResult, resolveProviderModel, runLlmAiReview } from '@/server/ai/providers/llmProviderShared';
+
+export const openAiAiReviewProvider: AiReviewProvider = {
+  id: 'openai',
+  async generateSuggestions(input, inputHash) {
+    const cfg = getAiReviewRuntimeConfig();
+    if (!cfg.openai.apiKey) {
+      return misconfiguredResult('openai', inputHash, 'OPENAI_API_KEY is not set');
+    }
+    const modelOrErr = resolveProviderModel('openai', cfg.openai.model, cfg.openai.allowedModels, inputHash);
+    if (typeof modelOrErr !== 'string') {
+      return modelOrErr;
+    }
+    return runLlmAiReview({
+      provider: 'openai',
+      model: modelOrErr,
+      input,
+      inputHash,
+      call: (messages) =>
+        openAiCompatibleChat({
+          url: 'https://api.openai.com/v1/chat/completions',
+          apiKey: cfg.openai.apiKey!,
+          model: modelOrErr,
+          messages,
+          timeoutMs: cfg.timeoutMs,
+          responseFormatJson: true,
+        }),
+    });
+  },
+};

--- a/src/server/ai/providers/openRouterProvider.ts
+++ b/src/server/ai/providers/openRouterProvider.ts
@@ -1,0 +1,44 @@
+import 'server-only';
+
+import { getAiAppReferer, getAiAppTitle, getAiReviewRuntimeConfig } from '@/server/ai/aiReviewConfig';
+import { openAiCompatibleChat } from '@/server/ai/aiReviewFetch';
+import type { AiReviewProvider } from '@/server/ai/aiReviewTypes';
+import { misconfiguredResult, resolveProviderModel, runLlmAiReview } from '@/server/ai/providers/llmProviderShared';
+
+export const openRouterAiReviewProvider: AiReviewProvider = {
+  id: 'openrouter',
+  async generateSuggestions(input, inputHash) {
+    const cfg = getAiReviewRuntimeConfig();
+    if (!cfg.openrouter.apiKey) {
+      return misconfiguredResult('openrouter', inputHash, 'OPENROUTER_API_KEY is not set');
+    }
+    const modelOrErr = resolveProviderModel(
+      'openrouter',
+      cfg.openrouter.model,
+      cfg.openrouter.allowedModels,
+      inputHash,
+    );
+    if (typeof modelOrErr !== 'string') {
+      return modelOrErr;
+    }
+    return runLlmAiReview({
+      provider: 'openrouter',
+      model: modelOrErr,
+      input,
+      inputHash,
+      call: (messages) =>
+        openAiCompatibleChat({
+          url: 'https://openrouter.ai/api/v1/chat/completions',
+          apiKey: cfg.openrouter.apiKey!,
+          extraHeaders: {
+            'HTTP-Referer': getAiAppReferer(),
+            'X-Title': getAiAppTitle(),
+          },
+          model: modelOrErr,
+          messages,
+          timeoutMs: cfg.timeoutMs,
+          responseFormatJson: true,
+        }),
+    });
+  },
+};

--- a/src/server/ai/runImportAiReview.ts
+++ b/src/server/ai/runImportAiReview.ts
@@ -63,6 +63,11 @@ export async function runImportAiReview(
     return { ok: true, result: disabledAiReviewResult() };
   }
 
+  const built = await buildAiReviewInput(importId, baseline);
+  if (!built) {
+    return { ok: false, notFound: true };
+  }
+
   const cookieStore = await cookies();
   const sessionKey = aiReviewRateLimitKey(cookieStore.get('admin_session')?.value);
   const limit = checkAiReviewRateLimit(sessionKey, cfg.rateLimitPerHour);
@@ -82,11 +87,6 @@ export async function runImportAiReview(
         error: 'AI review rate limit exceeded. Try again later.',
       },
     };
-  }
-
-  const built = await buildAiReviewInput(importId, baseline);
-  if (!built) {
-    return { ok: false, notFound: true };
   }
 
   const provider = getAiReviewProvider(cfg.provider);

--- a/src/server/ai/runImportAiReview.ts
+++ b/src/server/ai/runImportAiReview.ts
@@ -1,0 +1,105 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+import { getAiReviewRuntimeConfig } from '@/server/ai/aiReviewConfig';
+import { aiReviewRateLimitKey, checkAiReviewRateLimit } from '@/server/ai/aiReviewRateLimit';
+import { AI_REVIEW_DISCLAIMERS, type AiReviewSuggestionResult } from '@/server/ai/aiReviewTypes';
+import { buildAiReviewInput } from '@/server/ai/buildAiReviewInput';
+import { getAiReviewProvider } from '@/server/ai/providerRegistry';
+import { recordContentEvent } from '@/server/content/contentEvents';
+import type { ReviewBaselineMode } from '@/server/imports/reviewBaseline';
+
+export type RunImportAiReviewResult =
+  | { ok: true; result: AiReviewSuggestionResult; rateLimited?: false }
+  | { ok: false; rateLimited: true; result: AiReviewSuggestionResult };
+
+function disabledAiReviewResult(): AiReviewSuggestionResult {
+  return {
+    advisory: true,
+    enabled: false,
+    provider: 'none',
+    status: 'disabled',
+    generatedAt: new Date().toISOString(),
+    inputHash: '',
+    disclaimers: [...AI_REVIEW_DISCLAIMERS],
+    error: 'AI_PROVIDER is none. Set AI_PROVIDER and provider credentials to enable suggestions.',
+  };
+}
+
+async function logAiReviewAttempt(input: {
+  importId: string;
+  provider: string;
+  model?: string;
+  inputHash: string;
+  status: string;
+  suggestionCount: number;
+}) {
+  try {
+    await recordContentEvent({
+      eventType: 'SYSTEM_NOTE',
+      payload: {
+        kind: 'AI_IMPORT_REVIEW',
+        importId: input.importId,
+        provider: input.provider,
+        model: input.model ?? null,
+        inputHash: input.inputHash,
+        status: input.status,
+        suggestionCount: input.suggestionCount,
+      },
+    });
+  } catch (e) {
+    console.warn('[ai-review] audit log failed', e);
+  }
+}
+
+export async function runImportAiReview(
+  importId: string,
+  baseline: ReviewBaselineMode,
+): Promise<RunImportAiReviewResult | { ok: false; notFound: true }> {
+  const cfg = getAiReviewRuntimeConfig();
+
+  if (cfg.provider === 'none') {
+    return { ok: true, result: disabledAiReviewResult() };
+  }
+
+  const cookieStore = await cookies();
+  const sessionKey = aiReviewRateLimitKey(cookieStore.get('admin_session')?.value);
+  const limit = checkAiReviewRateLimit(sessionKey, cfg.rateLimitPerHour);
+
+  if (!limit.allowed) {
+    return {
+      ok: false,
+      rateLimited: true,
+      result: {
+        advisory: true,
+        enabled: true,
+        provider: cfg.provider,
+        status: 'error',
+        generatedAt: new Date().toISOString(),
+        inputHash: '',
+        disclaimers: [...AI_REVIEW_DISCLAIMERS],
+        error: 'AI review rate limit exceeded. Try again later.',
+      },
+    };
+  }
+
+  const built = await buildAiReviewInput(importId, baseline);
+  if (!built) {
+    return { ok: false, notFound: true };
+  }
+
+  const provider = getAiReviewProvider(cfg.provider);
+  const result = await provider.generateSuggestions(built.input, built.inputHash);
+
+  await logAiReviewAttempt({
+    importId,
+    provider: result.provider,
+    model: result.model,
+    inputHash: result.inputHash,
+    status: result.status,
+    suggestionCount: result.sectionNotes?.length ?? 0,
+  });
+
+  return { ok: true, result };
+}

--- a/src/tests/imports/aiReviewFetch.test.ts
+++ b/src/tests/imports/aiReviewFetch.test.ts
@@ -1,0 +1,49 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { openAiCompatibleChat } from '@/server/ai/aiReviewFetch';
+import { isAiProviderTimeoutError } from '@/server/ai/providers/llmProviderShared';
+
+describe('aiReviewFetch timeout', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('aborts when headers resolve but body read stalls', async () => {
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      const signal = init?.signal;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener('abort', () => {
+              reject(new DOMException('The operation was aborted.', 'AbortError'));
+            });
+          }),
+        text: () =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener('abort', () => {
+              reject(new DOMException('The operation was aborted.', 'AbortError'));
+            });
+          }),
+      } as Response);
+    });
+
+    await expect(
+      openAiCompatibleChat({
+        url: 'https://example.com/v1/chat/completions',
+        apiKey: 'sk-test',
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'hi' }],
+        timeoutMs: 50,
+      }),
+    ).rejects.toSatisfy((e) => isAiProviderTimeoutError(e));
+  });
+});

--- a/src/tests/imports/aiReviewParse.test.ts
+++ b/src/tests/imports/aiReviewParse.test.ts
@@ -1,0 +1,52 @@
+/** @vitest-environment node */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { parseLlmJsonContent } from '@/server/ai/aiReviewParse';
+
+const validPayload = {
+  summary: 'Review patents manually.',
+  sectionNotes: [
+    {
+      sectionId: 'patents',
+      severity: 'warning' as const,
+      message: 'Count mismatch',
+      suggestedAction: 'check_counts' as const,
+    },
+  ],
+};
+
+describe('parseLlmJsonContent', () => {
+  it('parses raw JSON', () => {
+    const parsed = parseLlmJsonContent(JSON.stringify(validPayload));
+    expect(parsed?.summary).toBe('Review patents manually.');
+  });
+
+  it('parses fenced JSON', () => {
+    const parsed = parseLlmJsonContent(`\`\`\`json\n${JSON.stringify(validPayload)}\n\`\`\``);
+    expect(parsed?.sectionNotes?.[0]?.sectionId).toBe('patents');
+  });
+
+  it('parses prose before and after fenced JSON', () => {
+    const parsed = parseLlmJsonContent(
+      `Here is the review:\n\`\`\`json\n${JSON.stringify(validPayload)}\n\`\`\`\nThanks.`,
+    );
+    expect(parsed?.summary).toBe('Review patents manually.');
+  });
+
+  it('parses JSON object embedded in prose', () => {
+    const parsed = parseLlmJsonContent(`Analysis complete. ${JSON.stringify(validPayload)} End.`);
+    expect(parsed?.summary).toBe('Review patents manually.');
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseLlmJsonContent('not json at all')).toBeNull();
+  });
+
+  it('returns null for wrong schema', () => {
+    expect(parseLlmJsonContent(JSON.stringify({ summary: '' }))).toBeNull();
+    expect(parseLlmJsonContent(JSON.stringify({ nope: true }))).toBeNull();
+  });
+});

--- a/src/tests/imports/aiReviewRateLimit.test.ts
+++ b/src/tests/imports/aiReviewRateLimit.test.ts
@@ -1,0 +1,32 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import {
+  aiReviewRateLimitBucketCountForTests,
+  checkAiReviewRateLimit,
+  resetAiReviewRateLimitsForTests,
+} from '@/server/ai/aiReviewRateLimit';
+
+describe('aiReviewRateLimit', () => {
+  beforeEach(() => {
+    resetAiReviewRateLimitsForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetAiReviewRateLimitsForTests();
+    vi.useRealTimers();
+  });
+
+  it('prunes expired unrelated buckets during check', () => {
+    checkAiReviewRateLimit('expired-key', 10);
+    vi.advanceTimersByTime(61 * 60 * 1000);
+    checkAiReviewRateLimit('active-key', 10);
+    expect(aiReviewRateLimitBucketCountForTests()).toBe(1);
+    checkAiReviewRateLimit('active-key', 10);
+    expect(aiReviewRateLimitBucketCountForTests()).toBe(1);
+  });
+});

--- a/src/tests/imports/aiReviewRedact.test.ts
+++ b/src/tests/imports/aiReviewRedact.test.ts
@@ -1,0 +1,39 @@
+/** @vitest-environment node */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { redactSensitiveText } from '@/server/ai/aiReviewRedact';
+
+describe('redactSensitiveText', () => {
+  it('preserves ISO and DMY dates', () => {
+    expect(redactSensitiveText('Published 2020-01-15 and 15/01/2020')).toBe(
+      'Published 2020-01-15 and 15/01/2020',
+    );
+    expect(redactSensitiveText('Updated 2020.01.15')).toBe('Updated 2020.01.15');
+    expect(redactSensitiveText('Deadline 31-12-2024')).toBe('Deadline 31-12-2024');
+  });
+
+  it('preserves year ranges and standalone years', () => {
+    expect(redactSensitiveText('Experience 2010-2020 and year 2019')).toBe(
+      'Experience 2010-2020 and year 2019',
+    );
+  });
+
+  it('redacts international and Korean-style phone numbers', () => {
+    expect(redactSensitiveText('Call +1-555-123-4567')).toContain('[redacted-phone]');
+    expect(redactSensitiveText('Mobile 010-1234-5678')).toContain('[redacted-phone]');
+    expect(redactSensitiveText('KR +82-10-1234-5678')).toContain('[redacted-phone]');
+  });
+
+  it('does not redact short ordinary numbers', () => {
+    expect(redactSensitiveText('5 publications and 3 awards')).toBe('5 publications and 3 awards');
+  });
+
+  it('redacts emails and urls', () => {
+    const out = redactSensitiveText('Email a@b.co url https://x.test/y');
+    expect(out).toContain('[redacted-email]');
+    expect(out).toContain('[redacted-url]');
+  });
+});

--- a/src/tests/imports/importAiReview.test.ts
+++ b/src/tests/imports/importAiReview.test.ts
@@ -289,7 +289,22 @@ describe('import AI review', () => {
       const provider = getAiReviewProvider('openai');
       const result = await provider.generateSuggestions(built!.input, built!.inputHash);
       expect(result.advisory).toBe(true);
-      expect(['timeout', 'error']).toContain(result.status);
+      expect(result.status).toBe('timeout');
+    });
+  });
+
+  describe('rate limit ordering', () => {
+    it('does not consume rate limit when import is not found', async () => {
+      process.env.AI_PROVIDER = 'openai';
+      process.env.OPENAI_API_KEY = 'sk-test';
+      process.env.OPENAI_MODEL = 'gpt-4o-mini';
+      process.env.OPENAI_ALLOWED_MODELS = 'gpt-4o-mini';
+      vi.mocked(getContentImportDetail).mockResolvedValue(null);
+      const rateLimitSpy = vi.spyOn(aiReviewRateLimit, 'checkAiReviewRateLimit');
+      const outcome = await runImportAiReview('missing-import', 'auto');
+      expect(outcome).toEqual({ ok: false, notFound: true });
+      expect(rateLimitSpy).not.toHaveBeenCalled();
+      rateLimitSpy.mockRestore();
     });
   });
 
@@ -371,7 +386,8 @@ describe('import AI review', () => {
   });
 
   describe('audit logging', () => {
-    it('records minimal AI_IMPORT_REVIEW event for enabled provider without prompt text', async () => {
+    it('records minimal AI_IMPORT_REVIEW event without private raw text sentinel', async () => {
+      const PRIVATE_SENTINEL = 'SENTINEL_RAW_9f3c_private_audit_leak_test';
       process.env.AI_PROVIDER = 'openai';
       process.env.OPENAI_API_KEY = 'sk-test';
       process.env.OPENAI_MODEL = 'gpt-4o-mini';
@@ -385,20 +401,18 @@ describe('import AI review', () => {
         ),
       );
       const details = minimalImportDetails();
-      mockImportRow(envelopeFromDetails(details, 'cv'));
+      mockImportRow(envelopeFromDetails(details, PRIVATE_SENTINEL));
       await runImportAiReview(IMPORT_ID, 'auto');
-      expect(recordContentEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          eventType: 'SYSTEM_NOTE',
-          payload: expect.objectContaining({
-            kind: 'AI_IMPORT_REVIEW',
-            importId: IMPORT_ID,
-            provider: 'openai',
-          }),
-        }),
-      );
-      const call = vi.mocked(recordContentEvent).mock.calls[0]?.[0];
-      expect(JSON.stringify(call)).not.toContain('cv');
+      const aiEvent = vi
+        .mocked(recordContentEvent)
+        .mock.calls.map((call) => call[0])
+        .find(
+          (event) =>
+            event.eventType === 'SYSTEM_NOTE' &&
+            (event.payload as { kind?: string }).kind === 'AI_IMPORT_REVIEW',
+        );
+      expect(aiEvent).toBeDefined();
+      expect(JSON.stringify(aiEvent)).not.toContain(PRIVATE_SENTINEL);
     });
   });
 

--- a/src/tests/imports/importAiReview.test.ts
+++ b/src/tests/imports/importAiReview.test.ts
@@ -1,0 +1,416 @@
+/** @vitest-environment node */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    get: (name: string) => (name === 'admin_session' ? { value: 'sess-test' } : undefined),
+  })),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  hasValidAdminAccess: vi.fn(),
+}));
+
+vi.mock('@/server/admin/contentWorkflowAccess', () => ({
+  requireFullAdminAccessForContent: vi.fn(),
+}));
+
+vi.mock('@/server/imports/repository', () => ({
+  getContentImportDetail: vi.fn(),
+  getPriorImportSourceTextHash: vi.fn(),
+}));
+
+vi.mock('@/server/content/contentWorkflowCore', async () => {
+  const actual = await vi.importActual('@/server/content/contentWorkflowCore');
+  return {
+    ...(actual as Record<string, unknown>),
+    getWorkingDraft: vi.fn(),
+    getLatestPublishedVersion: vi.fn(),
+  };
+});
+
+vi.mock('@/server/content/contentEvents', () => ({
+  recordContentEvent: vi.fn(),
+}));
+
+import { hasValidAdminAccess } from '@/lib/admin-auth';
+import { requireFullAdminAccessForContent } from '@/server/admin/contentWorkflowAccess';
+import * as aiReviewRateLimit from '@/server/ai/aiReviewRateLimit';
+import { redactSensitiveText } from '@/server/ai/aiReviewRedact';
+import { buildAiReviewInput, hashAiReviewInput } from '@/server/ai/buildAiReviewInput';
+import { getAiReviewProvider } from '@/server/ai/providerRegistry';
+import { runImportAiReview } from '@/server/ai/runImportAiReview';
+import { recordContentEvent } from '@/server/content/contentEvents';
+import { getLatestPublishedVersion, getWorkingDraft } from '@/server/content/contentWorkflowCore';
+import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
+import { buildImportReviewPayload } from '@/server/imports/importReviewCompare';
+import { getContentImportDetail, getPriorImportSourceTextHash } from '@/server/imports/repository';
+import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
+
+const IMPORT_ID = 'imp-ai-review';
+
+function envelopeFromDetails(
+  details: ReturnType<typeof minimalImportDetails>,
+  rawDocumentText: string,
+  importWarnings: { message: string; code?: string }[] = [],
+) {
+  return buildImportCandidatePayload({
+    rawDocumentText,
+    parserVersion: 't',
+    details,
+    sections: [],
+    importWarnings,
+  });
+}
+
+function mockImportRow(envelope: ReturnType<typeof buildImportCandidatePayload>) {
+  vi.mocked(getContentImportDetail).mockResolvedValue({
+    id: IMPORT_ID,
+    status: 'PARSED',
+    parserVersion: 't',
+    candidatePayload: envelope,
+    warnings: [],
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    uploadedFile: {
+      originalName: 'cv.docx',
+      storedPath: '/uploads/cv.docx',
+      id: 'uf-ai',
+    },
+    versions: [],
+  } as never);
+}
+
+describe('import AI review', () => {
+  const envBackup = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...envBackup };
+    vi.mocked(hasValidAdminAccess).mockReset();
+    vi.mocked(requireFullAdminAccessForContent).mockReset();
+    vi.mocked(getContentImportDetail).mockReset();
+    vi.mocked(getPriorImportSourceTextHash).mockReset();
+    vi.mocked(getWorkingDraft).mockReset();
+    vi.mocked(getLatestPublishedVersion).mockReset();
+    vi.mocked(recordContentEvent).mockReset();
+    vi.mocked(getPriorImportSourceTextHash).mockResolvedValue(null);
+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+    vi.mocked(getLatestPublishedVersion).mockResolvedValue(null);
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    process.env = envBackup;
+    vi.unstubAllGlobals();
+  });
+
+  describe('auth', () => {
+    it('rejects unauthenticated AI review route', async () => {
+      vi.mocked(requireFullAdminAccessForContent).mockResolvedValue(
+        NextResponse.json({ ok: false, error: 'UNAUTHORIZED' }, { status: 401 }),
+      );
+      const { POST } = await import('@/app/api/admin/imports/[id]/ai-review/route');
+      const res = await POST(
+        new NextRequest('http://localhost/api/admin/imports/x/ai-review', {
+          method: 'POST',
+          body: JSON.stringify({ baseline: 'auto' }),
+        }),
+        { params: Promise.resolve({ id: IMPORT_ID }) },
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects session without registered device', async () => {
+      vi.mocked(requireFullAdminAccessForContent).mockResolvedValue(
+        NextResponse.json({ ok: false, error: 'DEVICE_REQUIRED' }, { status: 403 }),
+      );
+      const { POST } = await import('@/app/api/admin/imports/[id]/ai-review/route');
+      const res = await POST(
+        new NextRequest('http://localhost/api/admin/imports/x/ai-review', { method: 'POST', body: '{}' }),
+        { params: Promise.resolve({ id: IMPORT_ID }) },
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('allows full admin/device access', async () => {
+      vi.mocked(requireFullAdminAccessForContent).mockResolvedValue(null);
+      process.env.AI_PROVIDER = 'none';
+      const { POST } = await import('@/app/api/admin/imports/[id]/ai-review/route');
+      const res = await POST(
+        new NextRequest('http://localhost/api/admin/imports/x/ai-review', { method: 'POST', body: '{}' }),
+        { params: Promise.resolve({ id: IMPORT_ID }) },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.result.advisory).toBe(true);
+      expect(json.result.status).toBe('disabled');
+    });
+  });
+
+  describe('provider none', () => {
+    it('returns disabled advisory when AI_PROVIDER unset without loading import', async () => {
+      delete process.env.AI_PROVIDER;
+      const rateLimitSpy = vi.spyOn(aiReviewRateLimit, 'checkAiReviewRateLimit');
+      const outcome = await runImportAiReview(IMPORT_ID, 'auto');
+      expect(outcome).toMatchObject({ ok: true });
+      if (!('ok' in outcome) || !outcome.ok) {
+        throw new Error('expected ok');
+      }
+      expect(outcome.result.advisory).toBe(true);
+      expect(outcome.result.enabled).toBe(false);
+      expect(outcome.result.status).toBe('disabled');
+      expect(outcome.result.provider).toBe('none');
+      expect(outcome.result.inputHash).toBe('');
+      expect(getContentImportDetail).not.toHaveBeenCalled();
+      expect(rateLimitSpy).not.toHaveBeenCalled();
+      expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+      rateLimitSpy.mockRestore();
+    });
+
+    it('does not consume rate limit on repeated disabled requests', async () => {
+      delete process.env.AI_PROVIDER;
+      process.env.AI_IMPORT_REVIEW_RATE_LIMIT_PER_HOUR = '1';
+      const rateLimitSpy = vi.spyOn(aiReviewRateLimit, 'checkAiReviewRateLimit');
+      await runImportAiReview(IMPORT_ID, 'auto');
+      await runImportAiReview(IMPORT_ID, 'auto');
+      expect(rateLimitSpy).not.toHaveBeenCalled();
+      rateLimitSpy.mockRestore();
+    });
+  });
+
+  describe('misconfigured providers', () => {
+    it('openai without API key returns misconfigured advisory', async () => {
+      process.env.AI_PROVIDER = 'openai';
+      delete process.env.OPENAI_API_KEY;
+      process.env.OPENAI_MODEL = 'gpt-4o-mini';
+      process.env.OPENAI_ALLOWED_MODELS = 'gpt-4o-mini';
+      const details = minimalImportDetails();
+      mockImportRow(envelopeFromDetails(details, 'cv'));
+      const built = await buildAiReviewInput(IMPORT_ID, 'auto');
+      expect(built).not.toBeNull();
+      const provider = getAiReviewProvider('openai');
+      const result = await provider.generateSuggestions(built!.input, built!.inputHash);
+      expect(result.advisory).toBe(true);
+      expect(result.status).toBe('misconfigured');
+      expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    });
+
+    it('ollama unavailable returns advisory error without throwing', async () => {
+      process.env.AI_PROVIDER = 'ollama';
+      process.env.OLLAMA_MODEL = 'llama3.1:8b';
+      process.env.OLLAMA_ALLOWED_MODELS = 'llama3.1:8b';
+      vi.mocked(fetch).mockRejectedValue(new Error('ECONNREFUSED'));
+      const details = minimalImportDetails();
+      mockImportRow(envelopeFromDetails(details, 'cv'));
+      const built = await buildAiReviewInput(IMPORT_ID, 'auto');
+      const provider = getAiReviewProvider('ollama');
+      const result = await provider.generateSuggestions(built!.input, built!.inputHash);
+      expect(result.advisory).toBe(true);
+      expect(result.status).toBe('error');
+      expect(result.error).toBeTruthy();
+    });
+  });
+
+  describe('mock provider fetch', () => {
+    it('returns structured suggestions from valid provider JSON', async () => {
+      process.env.AI_PROVIDER = 'openai';
+      process.env.OPENAI_API_KEY = 'sk-test';
+      process.env.OPENAI_MODEL = 'gpt-4o-mini';
+      process.env.OPENAI_ALLOWED_MODELS = 'gpt-4o-mini';
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    summary: 'Patent counts look suspicious; review manually.',
+                    sectionNotes: [
+                      {
+                        sectionId: 'patents',
+                        severity: 'warning',
+                        message: 'Declared vs extracted patent count differs.',
+                        suggestedAction: 'check_counts',
+                      },
+                    ],
+                  }),
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+      const details = minimalImportDetails();
+      mockImportRow(envelopeFromDetails(details, 'cv'));
+      const outcome = await runImportAiReview(IMPORT_ID, 'auto');
+      expect(outcome).toMatchObject({ ok: true });
+      if (!('ok' in outcome) || !outcome.ok) {
+        throw new Error('expected ok');
+      }
+      expect(outcome.result.status).toBe('ok');
+      expect(outcome.result.summary).toContain('Patent');
+      expect(outcome.result.sectionNotes?.[0]?.sectionId).toBe('patents');
+    });
+
+    it('malformed provider JSON returns advisory error', async () => {
+      process.env.AI_PROVIDER = 'groq';
+      process.env.GROQ_API_KEY = 'gsk-test';
+      process.env.GROQ_MODEL = 'llama-3.1-8b-instant';
+      process.env.GROQ_ALLOWED_MODELS = 'llama-3.1-8b-instant';
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({ choices: [{ message: { content: 'not json at all' } }] }),
+          { status: 200 },
+        ),
+      );
+      const details = minimalImportDetails();
+      mockImportRow(envelopeFromDetails(details, 'cv'));
+      const built = await buildAiReviewInput(IMPORT_ID, 'auto');
+      const provider = getAiReviewProvider('groq');
+      const result = await provider.generateSuggestions(built!.input, built!.inputHash);
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('malformed');
+    });
+
+    it('timeout is handled as advisory timeout', async () => {
+      process.env.AI_PROVIDER = 'openai';
+      process.env.OPENAI_API_KEY = 'sk-test';
+      process.env.OPENAI_MODEL = 'gpt-4o-mini';
+      process.env.OPENAI_ALLOWED_MODELS = 'gpt-4o-mini';
+      vi.mocked(fetch).mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError'));
+      const details = minimalImportDetails();
+      mockImportRow(envelopeFromDetails(details, 'cv'));
+      const built = await buildAiReviewInput(IMPORT_ID, 'auto');
+      const provider = getAiReviewProvider('openai');
+      const result = await provider.generateSuggestions(built!.input, built!.inputHash);
+      expect(result.advisory).toBe(true);
+      expect(['timeout', 'error']).toContain(result.status);
+    });
+  });
+
+  describe('no mutation', () => {
+    it('disabled AI review does not read import row', async () => {
+      process.env.AI_PROVIDER = 'none';
+      await runImportAiReview(IMPORT_ID, 'auto');
+      expect(getContentImportDetail).not.toHaveBeenCalled();
+      expect(recordContentEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('data minimization', () => {
+    it('buildAiReviewInput excludes rawDocumentText and redacts contact values', async () => {
+      const raw = 'Contact: prof@uni.edu https://example.com +1-555-123-4567\nPatents (52)\nbody';
+      const details = minimalImportDetails({
+        contact: {
+          ...minimalImportDetails().contact,
+          email: 'prof@uni.edu',
+          phone: '+1-555-123-4567',
+          website: 'https://example.com',
+        },
+      });
+      const envelope = envelopeFromDetails(details, raw, [
+        { code: 'CONTACT_HINT', message: 'Found email prof@uni.edu and https://secret.example/path' },
+      ]);
+      mockImportRow(envelope);
+      const built = await buildAiReviewInput(IMPORT_ID, 'auto');
+      expect(built).not.toBeNull();
+      const serialized = JSON.stringify(built!.input);
+      expect(serialized).not.toContain('rawDocumentText');
+      expect(serialized).not.toContain('prof@uni.edu');
+      expect(serialized).not.toContain('https://example.com');
+      expect(serialized).not.toContain('https://secret.example');
+      expect(serialized).toContain('[redacted-email]');
+      expect(serialized).toContain('[redacted-url]');
+      expect(built!.input.mergeSafety.sections.length).toBeGreaterThan(0);
+      expect(built!.inputHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(hashAiReviewInput(built!.input)).toBe(built!.inputHash);
+    });
+
+    it('caps oversized input by dropping block previews', async () => {
+      process.env.AI_IMPORT_REVIEW_MAX_INPUT_CHARS = '5000';
+      const lines = Array.from(
+        { length: 80 },
+        (_, i) => `Publication line ${i} with extra padding text and more words to inflate review payload`,
+      );
+      const details = minimalImportDetails({
+        publications: lines.map((title, i) => ({
+          id: `pub-${i}`,
+          title,
+          authors: null,
+          journal: null,
+          year: 2020,
+          volume: null,
+          issue: null,
+          pages: null,
+          doi: null,
+          link: null,
+          type: 'journal' as const,
+          raw: null,
+        })),
+        counts: { publications: 80, patents: 0, projects: 0, awards: 0, students: 0 },
+      });
+      mockImportRow(envelopeFromDetails(details, 'x'.repeat(8000)));
+      const built = await buildAiReviewInput(IMPORT_ID, 'auto');
+      expect(built).not.toBeNull();
+      expect(JSON.stringify(built!.input).length).toBeLessThanOrEqual(5000);
+    });
+  });
+
+  describe('redact helper', () => {
+    it('redacts emails phones and urls', () => {
+      const out = redactSensitiveText('Email a@b.co phone 555-123-4567 url https://x.test/y');
+      expect(out).toContain('[redacted-email]');
+      expect(out).toContain('[redacted-phone]');
+      expect(out).toContain('[redacted-url]');
+    });
+  });
+
+  describe('audit logging', () => {
+    it('records minimal AI_IMPORT_REVIEW event for enabled provider without prompt text', async () => {
+      process.env.AI_PROVIDER = 'openai';
+      process.env.OPENAI_API_KEY = 'sk-test';
+      process.env.OPENAI_MODEL = 'gpt-4o-mini';
+      process.env.OPENAI_ALLOWED_MODELS = 'gpt-4o-mini';
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: JSON.stringify({ summary: 'ok' }) } }],
+          }),
+          { status: 200 },
+        ),
+      );
+      const details = minimalImportDetails();
+      mockImportRow(envelopeFromDetails(details, 'cv'));
+      await runImportAiReview(IMPORT_ID, 'auto');
+      expect(recordContentEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'SYSTEM_NOTE',
+          payload: expect.objectContaining({
+            kind: 'AI_IMPORT_REVIEW',
+            importId: IMPORT_ID,
+            provider: 'openai',
+          }),
+        }),
+      );
+      const call = vi.mocked(recordContentEvent).mock.calls[0]?.[0];
+      expect(JSON.stringify(call)).not.toContain('cv');
+    });
+  });
+
+  describe('merge safety unchanged', () => {
+    it('buildImportReviewPayload still defaults to safe_update with ack for full_replace', async () => {
+      const details = minimalImportDetails({
+        profile: { ...minimalImportDetails().profile, name: 'Safety Check' },
+      });
+      mockImportRow(envelopeFromDetails(details, 'cv'));
+      const review = await buildImportReviewPayload(IMPORT_ID);
+      expect(review.mergeSafety.defaultMergeMode).toBe('safe_update');
+      expect(review.mergeSafety.fullReplaceRequiresAck).toBe(true);
+    });
+  });
+});

--- a/src/tests/ui/importAiReviewPanel.test.tsx
+++ b/src/tests/ui/importAiReviewPanel.test.tsx
@@ -51,6 +51,20 @@ describe('ImportAiReviewAssistantPanel', () => {
     expect(screen.queryByRole('button', { name: /apply/i })).toBeNull();
   });
 
+  it('shows provider settings unavailable message on settings load failure', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ ok: false, message: 'server error' }),
+    });
+    render(<ImportAiReviewAssistantPanel importId="imp1" baselineMode="auto" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-provider-settings-error')).toBeTruthy();
+    });
+    expect(screen.getByText('Provider status is currently unavailable.')).toBeTruthy();
+    expect(screen.queryByTestId('ai-disabled-message')).toBeNull();
+    expect(screen.queryByTestId('ai-generate-button')).toBeNull();
+  });
+
   it('shows manual generate button and advisory results when enabled', async () => {
     fetchMock
       .mockResolvedValueOnce({

--- a/src/tests/ui/importAiReviewPanel.test.tsx
+++ b/src/tests/ui/importAiReviewPanel.test.tsx
@@ -1,0 +1,117 @@
+/** @vitest-environment happy-dom */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ImportAiReviewAssistantPanel } from '@/app/admin/imports/ImportAiReviewAssistantPanel';
+
+describe('ImportAiReviewAssistantPanel', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders disabled state when provider is none', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        settings: {
+          activeProvider: 'none',
+          activeModel: null,
+          switchingMode: 'env_only',
+          switchingNote: 'env driven',
+          providers: [
+            {
+              id: 'none',
+              label: 'Disabled',
+              status: 'disabled',
+              active: true,
+              model: null,
+              allowedModels: [],
+              statusMessage: 'off',
+            },
+          ],
+          disclaimers: ['Advisory only'],
+        },
+      }),
+    });
+    render(<ImportAiReviewAssistantPanel importId="imp1" baselineMode="auto" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-disabled-message')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('ai-generate-button')).toBeNull();
+    expect(screen.queryByRole('button', { name: /apply/i })).toBeNull();
+  });
+
+  it('shows manual generate button and advisory results when enabled', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          settings: {
+            activeProvider: 'ollama',
+            activeModel: 'llama3.1:8b',
+            switchingMode: 'env_only',
+            switchingNote: 'env driven',
+            providers: [
+              {
+                id: 'ollama',
+                label: 'Ollama',
+                status: 'configured',
+                active: true,
+                model: 'llama3.1:8b',
+                allowedModels: ['llama3.1:8b'],
+                statusMessage: 'ready',
+              },
+            ],
+            disclaimers: ['Advisory only'],
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          result: {
+            advisory: true,
+            enabled: true,
+            provider: 'ollama',
+            model: 'llama3.1:8b',
+            status: 'ok',
+            generatedAt: new Date().toISOString(),
+            inputHash: 'abc',
+            summary: 'Review patent counts manually.',
+            sectionNotes: [
+              {
+                sectionId: 'patents',
+                severity: 'warning',
+                message: 'Count mismatch',
+                suggestedAction: 'check_counts',
+              },
+            ],
+            disclaimers: ['Advisory only'],
+          },
+        }),
+      });
+
+    render(<ImportAiReviewAssistantPanel importId="imp1" baselineMode="auto" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-generate-button')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('ai-generate-button'));
+    await waitFor(() => {
+      expect(screen.getByText(/Review patent counts manually/i)).toBeTruthy();
+    });
+    expect(screen.getByText(/Count mismatch/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /apply/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Content / copy (CMS / seeds)
- [x] Refactor (no intended behavior change)
- [x] Docs / tooling only

## Checklist

- [x] `npm run tsc`
- [x] `npm run lint` (or note intentional exceptions)
- [x] `npm run test:run`
- [x] `npm run build` (if touching routes, server, or build config)
- [x] No secrets / credentials committed
- [ ] If `SiteContent` shape changed: schema + seeds + `src/tests/content/siteContent.test.ts` updated

## Notes for reviewers

<!-- Migrations, env vars, publish/import implications, screenshots if UI changed intentionally -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added optional AI review assistant for import workflows (disabled by default)
  - Supports multiple AI providers: Ollama, OpenRouter, Groq, and OpenAI
  - Includes data minimization and sensitive content redaction for privacy
  - New admin settings page to configure AI provider selection
  - Built-in rate limiting on AI review requests

* **Documentation**
  - Updated configuration guide with AI provider environment variables
  - Added admin workflow documentation for AI review functionality
  - Updated production release checklist with AI setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->