### PR TITLE
feat: add audited import reconciliation workflow

### DIFF
--- a/changes.diff
+++ b/changes.diff
@@ -1,0 +1,937 @@
+﻿diff --git a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+index 8674868..49ca33c 100644
+--- a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
++++ b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+@@ -154,6 +154,29 @@ function decisionControls(
+   );
+ }
+ 
++function approvalBadgeStatus(
++  draftApproval: LocalApproval | undefined,
++  serverApproval: LocalApproval | undefined,
++): 'pending' | 'unsaved' | 'saved' {
++  if (draftApproval) {
++    return 'unsaved';
++  }
++  if (serverApproval) {
++    return 'saved';
++  }
++  return 'pending';
++}
++
++function ApprovalStatusBadge({ status }: { status: 'pending' | 'unsaved' | 'saved' }) {
++  if (status === 'saved') {
++    return <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>;
++  }
++  if (status === 'unsaved') {
++    return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">unsaved</span>;
++  }
++  return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>;
++}
++
+ export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }: Props) {
+   const [draftApprovals, setDraftApprovals] = useState<LocalApproval[]>([]);
+   const [saving, setSaving] = useState(false);
+@@ -308,23 +331,22 @@ export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }:
+           <h3 className="text-sm font-medium text-foreground">{sectionLabel(section)}</h3>
+           <div className="space-y-3">
+             {decisions.map((decision) => {
++              const serverApproval = serverApprovals.find((a) => a.decisionId === decision.decisionId);
++              const draftApproval = draftApprovals.find((a) => a.decisionId === decision.decisionId);
+               const current = effectiveApprovals.get(decision.decisionId);
+-              const isCluster = Boolean(decision.relatedExistingIds && decision.relatedExistingIds.length > 0);
+-              const clusterMembers = isCluster
+-                ? [decision.existingId!, ...(decision.relatedExistingIds ?? [])]
+-                : [];
+-              const resolved = Boolean(current);
++              const clusterMemberIds = [decision.existingId, ...(decision.relatedExistingIds ?? [])].filter(
++                (id): id is string => Boolean(id),
++              );
++              const isCluster = clusterMemberIds.length >= 2;
++              const clusterMembers = isCluster ? clusterMemberIds : [];
++              const approvalStatus = approvalBadgeStatus(draftApproval, serverApproval as LocalApproval | undefined);
+ 
+               return (
+                 <div key={decision.decisionId} className="rounded border border-primary/15 p-3 text-xs space-y-2">
+                   <div className="flex flex-wrap items-center gap-2">
+                     <span className="font-medium text-foreground">{decision.action}</span>
+                     <span className="text-muted">confidence: {decision.confidence}</span>
+-                    {resolved ? (
+-                      <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>
+-                    ) : (
+-                      <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>
+-                    )}
++                    <ApprovalStatusBadge status={approvalStatus} />
+                   </div>
+                   <p className="text-foreground">{decision.reason}</p>
+                   {decision.existingId ? (
+diff --git a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
+index dbb13af..3dbecca 100644
+--- a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
++++ b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
+@@ -38,7 +38,8 @@ function mergeErrorResponse(e: ImportMergeError): NextResponse {
+     e.code === 'REVIEW_BLOCKED' ||
+     e.code === 'REVIEW_MANIFEST_MISSING' ||
+     e.code === 'REVIEW_MANIFEST_STALE' ||
+-    e.code === 'REVIEW_APPROVALS_STALE'
++    e.code === 'REVIEW_APPROVALS_STALE' ||
++    e.code === 'REVIEW_APPROVALS_INVALID'
+   ) {
+     status = 422;
+   }
+diff --git a/src/server/imports/importCandidateReview/reconcile.ts b/src/server/imports/importCandidateReview/reconcile.ts
+index 50c12d9..a714662 100644
+--- a/src/server/imports/importCandidateReview/reconcile.ts
++++ b/src/server/imports/importCandidateReview/reconcile.ts
+@@ -48,15 +48,25 @@ export type LoadedImportReviewState = {
+ export function loadImportReviewStateFromRow(row: {
+   reviewManifest: unknown;
+   reviewApprovals: unknown;
+-  candidatePayload: unknown;
+ }): LoadedImportReviewState | null {
+   const manifestEnvelope = parseStoredReviewManifest(row.reviewManifest);
+   if (!manifestEnvelope) {
+     return null;
+   }
+-  const approvalsEnvelope = row.reviewApprovals
+-    ? parseStoredReviewApprovals(row.reviewApprovals)
+-    : null;
++  const approvalsEnvelope =
++    row.reviewApprovals === null || row.reviewApprovals === undefined
++      ? null
++      : parseStoredReviewApprovals(row.reviewApprovals);
++  if (
++    row.reviewApprovals !== null &&
++    row.reviewApprovals !== undefined &&
++    approvalsEnvelope === null
++  ) {
++    throw new ImportReviewReconcileError(
++      'REVIEW_APPROVALS_INVALID',
++      'Stored review approvals are malformed.',
++    );
++  }
+   const approvals = approvalsEnvelope?.approvals ?? [];
+   let manifest = manifestEnvelope.manifest as CandidateReviewManifest;
+   if (approvals.length > 0) {
+diff --git a/src/server/imports/importCandidateReview/revision.ts b/src/server/imports/importCandidateReview/revision.ts
+index 0d19e82..15a741e 100644
+--- a/src/server/imports/importCandidateReview/revision.ts
++++ b/src/server/imports/importCandidateReview/revision.ts
+@@ -7,7 +7,10 @@ export function computeImportReviewManifestRevision(input: {
+   sourceTextHash: string;
+   decisionIds: readonly string[];
+ }): string {
+-  const payload = `${input.sourceTextHash}\n${[...input.decisionIds].sort().join('\n')}`;
++  const payload = JSON.stringify({
++    sourceTextHash: input.sourceTextHash,
++    decisionIds: [...input.decisionIds].sort(),
++  });
+   return createHash('sha256').update(payload).digest('hex').slice(0, 32);
+ }
+ 
+diff --git a/src/server/imports/importCandidateReview/service.ts b/src/server/imports/importCandidateReview/service.ts
+index 74008de..3b449d4 100644
+--- a/src/server/imports/importCandidateReview/service.ts
++++ b/src/server/imports/importCandidateReview/service.ts
+@@ -1,5 +1,6 @@
+ import 'server-only';
+ 
++import type { ImportStatus } from '@prisma/client';
+ import { Prisma } from '@prisma/client';
+ 
+ import { recordContentEvent } from '@/server/content/contentEvents';
+@@ -28,6 +29,21 @@ import {
+ } from '@/server/imports/importCandidateReview/storageSchema';
+ import { ImportDomainError } from '@/server/imports/types';
+ 
++const REVIEW_APPROVAL_ALLOWED_STATUSES = new Set<ImportStatus>(['PARSED', 'NEEDS_REVIEW']);
++
++export function importStatusAcceptsReviewApprovalUpdates(status: ImportStatus): boolean {
++  return REVIEW_APPROVAL_ALLOWED_STATUSES.has(status);
++}
++
++function assertImportStatusAcceptsReviewApprovalUpdates(status: ImportStatus): void {
++  if (!importStatusAcceptsReviewApprovalUpdates(status)) {
++    throw new ImportReviewApprovalPersistError(
++      'IMPORT_FINALIZED',
++      `Import status "${status}" does not accept review approval updates.`,
++    );
++  }
++}
++
+ export class ImportReviewApprovalPersistError extends Error {
+   constructor(
+     readonly code:
+@@ -137,14 +153,17 @@ export async function saveImportReviewApprovals(input: {
+   if (!row) {
+     throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
+   }
+-  if (row.status === 'REJECTED' || row.status === 'FAILED') {
+-    throw new ImportReviewApprovalPersistError(
+-      'IMPORT_FINALIZED',
+-      `Import status "${row.status}" does not accept review approval updates.`,
+-    );
+-  }
++  assertImportStatusAcceptsReviewApprovalUpdates(row.status);
+ 
+-  const loaded = loadImportReviewStateFromRow(row);
++  let loaded: ReturnType<typeof loadImportReviewStateFromRow>;
++  try {
++    loaded = loadImportReviewStateFromRow(row);
++  } catch (e) {
++    if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
++      throw new ImportReviewApprovalPersistError('REVIEW_APPROVALS_INVALID', e.message);
++    }
++    throw e;
++  }
+   if (!loaded) {
+     throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
+   }
+@@ -175,6 +194,7 @@ export async function saveImportReviewApprovals(input: {
+     if (!current) {
+       throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
+     }
++    assertImportStatusAcceptsReviewApprovalUpdates(current.status);
+     const currentLoaded = loadImportReviewStateFromRow(current);
+     if (!currentLoaded) {
+       throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
+diff --git a/src/server/imports/importCandidateReview/storageSchema.ts b/src/server/imports/importCandidateReview/storageSchema.ts
+index 6d2052f..10c07f0 100644
+--- a/src/server/imports/importCandidateReview/storageSchema.ts
++++ b/src/server/imports/importCandidateReview/storageSchema.ts
+@@ -60,23 +60,38 @@ const advisorySectionAccountingSchema = z.object({
+   affectedRecordCount: z.number().int().nonnegative(),
+ });
+ 
+-const candidateReviewManifestSchema = z.object({
+-  generatedAt: z.string(),
+-  importId: z.string().nullable().optional(),
+-  importSource: z.string(),
+-  baseline: reviewBaselineRefSchema,
+-  decisions: z.array(reviewDecisionSchema),
+-  analysisAccounting: z.object({
+-    publications: reconciledSectionAccountingSchema,
+-    awards: reconciledSectionAccountingSchema,
+-  }),
+-  accounting: z.object({
+-    publications: reconciledSectionAccountingSchema,
+-    awards: reconciledSectionAccountingSchema,
+-    patents: advisorySectionAccountingSchema,
+-    research: advisorySectionAccountingSchema,
+-  }),
+-});
++const candidateReviewManifestSchema = z
++  .object({
++    generatedAt: z.string(),
++    importId: z.string().nullable().optional(),
++    importSource: z.string(),
++    baseline: reviewBaselineRefSchema,
++    decisions: z.array(reviewDecisionSchema),
++    analysisAccounting: z.object({
++      publications: reconciledSectionAccountingSchema,
++      awards: reconciledSectionAccountingSchema,
++    }),
++    accounting: z.object({
++      publications: reconciledSectionAccountingSchema,
++      awards: reconciledSectionAccountingSchema,
++      patents: advisorySectionAccountingSchema,
++      research: advisorySectionAccountingSchema,
++    }),
++  })
++  .superRefine((value, ctx) => {
++    const seen = new Set<string>();
++    value.decisions.forEach((d, idx) => {
++      if (seen.has(d.decisionId)) {
++        ctx.addIssue({
++          code: z.ZodIssueCode.custom,
++          path: ['decisions', idx, 'decisionId'],
++          message: 'decisionId must be unique within a manifest.',
++        });
++        return;
++      }
++      seen.add(d.decisionId);
++    });
++  });
+ 
+ export const storedReviewManifestEnvelopeSchema = z.object({
+   storageVersion: z.literal(IMPORT_REVIEW_STORAGE_VERSION),
+diff --git a/src/server/imports/mergeImportToDraft.ts b/src/server/imports/mergeImportToDraft.ts
+index c79f927..d77ae32 100644
+--- a/src/server/imports/mergeImportToDraft.ts
++++ b/src/server/imports/mergeImportToDraft.ts
+@@ -42,7 +42,8 @@ export class ImportMergeError extends Error {
+       | 'REVIEW_BLOCKED'
+       | 'REVIEW_MANIFEST_MISSING'
+       | 'REVIEW_MANIFEST_STALE'
+-      | 'REVIEW_APPROVALS_STALE',
++      | 'REVIEW_APPROVALS_STALE'
++      | 'REVIEW_APPROVALS_INVALID',
+     message: string,
+   ) {
+     super(message);
+@@ -71,6 +72,50 @@ export type MergeImportCandidateResult = {
+   alreadyMerged: boolean;
+ };
+ 
++async function recordSuccessfulMergeEvents(input: {
++  versionId: string;
++  importId: string;
++  action: 'create' | 'replace';
++  draftEventType: 'WORKING_DRAFT_CREATED' | 'WORKING_DRAFT_UPDATED';
++  draftEventPayload: Prisma.InputJsonValue;
++  reconciledAccounting: Prisma.InputJsonValue | null;
++  unresolvedBlockingCount: number;
++  acknowledgedUnresolvedReview: boolean;
++  normalizedUnresolvedReviewReason: string | null;
++}): Promise<void> {
++  await recordContentEvent({
++    eventType: input.draftEventType,
++    versionId: input.versionId,
++    payload: input.draftEventPayload,
++  });
++  await recordContentEvent({
++    eventType: 'SYSTEM_NOTE',
++    versionId: input.versionId,
++    payload: {
++      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
++      importId: input.importId,
++      action: input.action,
++      reconciledAccounting: input.reconciledAccounting,
++      unresolvedBlockingCount: input.unresolvedBlockingCount,
++      acknowledgedUnresolvedReview: input.acknowledgedUnresolvedReview,
++      unresolvedReviewReason: input.normalizedUnresolvedReviewReason,
++    },
++  });
++  if (input.acknowledgedUnresolvedReview) {
++    await recordContentEvent({
++      eventType: 'SYSTEM_NOTE',
++      versionId: input.versionId,
++      payload: {
++        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
++        importId: input.importId,
++        versionId: input.versionId,
++        unresolvedBlockingCount: input.unresolvedBlockingCount,
++        reason: input.normalizedUnresolvedReviewReason,
++      },
++    });
++  }
++}
++
+ /**
+  * Creates a working draft from the import candidate, or replaces the existing draft payload.
+  * Never touches published rows. Sets `ContentVersion.importId` and marks the import `MERGED`.
+@@ -115,14 +160,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+   const baselineData = basePayload.data;
+ 
+   const manifestEnvelope = await ensureImportReviewManifest(input.importId);
++  // Reload after ensureImportReviewManifest ÔÇö it may have lazily generated and persisted a manifest.
+   const reviewRow = await getContentImportDetail(input.importId);
+-  const loadedReview = reviewRow
+-    ? loadImportReviewStateFromRow({
++  let loadedReview: ReturnType<typeof loadImportReviewStateFromRow> = null;
++  if (reviewRow) {
++    try {
++      loadedReview = loadImportReviewStateFromRow({
+         reviewManifest: reviewRow.reviewManifest,
+         reviewApprovals: reviewRow.reviewApprovals,
+-        candidatePayload: reviewRow.candidatePayload,
+-      })
+-    : null;
++      });
++    } catch (e) {
++      if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
++        throw new ImportMergeError('REVIEW_APPROVALS_INVALID', e.message);
++      }
++      throw e;
++    }
++  }
+   if (!loadedReview) {
+     throw new ImportMergeError('REVIEW_MANIFEST_MISSING', 'Import has no reconciliation review manifest.');
+   }
+@@ -166,29 +219,19 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+     throw e;
+   }
+ 
+-  if (
+-    input.acknowledgeUnresolvedReview &&
+-    unresolvedBlockingCount > 0 &&
+-    !input.unresolvedReviewReason?.trim()
+-  ) {
++  const acknowledgedUnresolvedReview =
++    Boolean(input.acknowledgeUnresolvedReview) && unresolvedBlockingCount > 0;
++  const normalizedUnresolvedReviewReason = acknowledgedUnresolvedReview
++    ? (input.unresolvedReviewReason?.trim() ?? '')
++    : '';
++
++  if (acknowledgedUnresolvedReview && normalizedUnresolvedReviewReason.length < 8) {
+     throw new ImportMergeError(
+       'MERGE_ACK_REQUIRED',
+-      'Unresolved reconciliation override requires unresolvedReviewReason.',
++      'Unresolved reconciliation override requires unresolvedReviewReason of at least 8 characters.',
+     );
+   }
+ 
+-  if (input.acknowledgeUnresolvedReview && unresolvedBlockingCount > 0) {
+-    await recordContentEvent({
+-      eventType: 'SYSTEM_NOTE',
+-      payload: {
+-        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+-        importId: input.importId,
+-        unresolvedBlockingCount,
+-        reason: input.unresolvedReviewReason?.trim() ?? null,
+-      },
+-    });
+-  }
+-
+   const provenance: ImportReviewProvenance = {
+     importId: importRow.id,
+     originalFileName: importRow.uploadedFile.originalName,
+@@ -244,29 +287,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+         createdBy: null,
+       },
+     });
+-    await recordContentEvent({
+-      eventType: 'WORKING_DRAFT_CREATED',
++    await recordSuccessfulMergeEvents({
+       versionId: row.id,
+-      payload: {
++      importId: input.importId,
++      action: 'create',
++      draftEventType: 'WORKING_DRAFT_CREATED',
++      draftEventPayload: {
+         importId: input.importId,
+         source: 'import_candidate',
+         reconciledAccounting,
+         unresolvedBlockingCount,
+-        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+-      },
+-    });
+-    await recordContentEvent({
+-      eventType: 'SYSTEM_NOTE',
+-      versionId: row.id,
+-      payload: {
+-        kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+-        importId: input.importId,
+-        action: 'create',
+-        reconciledAccounting,
+-        unresolvedBlockingCount,
+-        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+-        unresolvedReviewReason: input.unresolvedReviewReason ?? null,
++        acknowledgedUnresolvedReview,
+       },
++      reconciledAccounting,
++      unresolvedBlockingCount,
++      acknowledgedUnresolvedReview,
++      normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
+     });
+     await updateImportStatus(input.importId, 'MERGED');
+     return { version: row, alreadyMerged: false };
+@@ -283,29 +319,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+       changeSummary: input.changeSummary ?? working.changeSummary,
+     },
+   });
+-  await recordContentEvent({
+-    eventType: 'WORKING_DRAFT_UPDATED',
++  await recordSuccessfulMergeEvents({
+     versionId: row.id,
+-    payload: {
++    importId: input.importId,
++    action: 'replace',
++    draftEventType: 'WORKING_DRAFT_UPDATED',
++    draftEventPayload: {
+       importId: input.importId,
+       source: 'import_candidate_replace',
+       reconciledAccounting,
+       unresolvedBlockingCount,
+-      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+-    },
+-  });
+-  await recordContentEvent({
+-    eventType: 'SYSTEM_NOTE',
+-    versionId: row.id,
+-    payload: {
+-      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+-      importId: input.importId,
+-      action: 'replace',
+-      reconciledAccounting,
+-      unresolvedBlockingCount,
+-      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+-      unresolvedReviewReason: input.unresolvedReviewReason ?? null,
++      acknowledgedUnresolvedReview,
+     },
++    reconciledAccounting,
++    unresolvedBlockingCount,
++    acknowledgedUnresolvedReview,
++    normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
+   });
+   await updateImportStatus(input.importId, 'MERGED');
+   return { version: row, alreadyMerged: false };
+diff --git a/src/server/imports/serialize.ts b/src/server/imports/serialize.ts
+index 170d65f..bc022ed 100644
+--- a/src/server/imports/serialize.ts
++++ b/src/server/imports/serialize.ts
+@@ -144,7 +144,6 @@ export function buildImportCandidateReconcileReview(
+   const loaded = loadImportReviewStateFromRow({
+     reviewManifest: row.reviewManifest,
+     reviewApprovals: row.reviewApprovals,
+-    candidatePayload: null,
+   });
+   if (!loaded) {
+     return null;
+diff --git a/src/tests/imports/importCandidateReconcilePanel.test.tsx b/src/tests/imports/importCandidateReconcilePanel.test.tsx
+index 9cbd070..785a795 100644
+--- a/src/tests/imports/importCandidateReconcilePanel.test.tsx
++++ b/src/tests/imports/importCandidateReconcilePanel.test.tsx
+@@ -1,6 +1,6 @@
+ /** @vitest-environment happy-dom */
+ 
+-import { fireEvent, render, screen } from '@testing-library/react';
++import { fireEvent, render, screen, within } from '@testing-library/react';
+ import { describe, expect, it, vi } from 'vitest';
+ 
+ import { ImportCandidateReconcilePanel } from '@/app/admin/imports/ImportCandidateReconcilePanel';
+@@ -82,6 +82,33 @@ describe('ImportCandidateReconcilePanel', () => {
+     expect(screen.getByRole('button', { name: /Remove entire cluster/i })).toBeTruthy();
+   });
+ 
++  it('shows unsaved badge for local draft approval before save', () => {
++    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={vi.fn()} />);
++    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div')!;
++    expect(artifactCard.textContent).toContain('pending');
++    fireEvent.click(within(artifactCard).getByRole('button', { name: /Approve removal/i }));
++    expect(artifactCard.textContent).toContain('unsaved');
++    expect(within(artifactCard).getByText('unsaved')).toBeTruthy();
++  });
++
++  it('shows saved badge for server-persisted approval', () => {
++    const withSavedApproval: ImportCandidateReconcileReviewModel = {
++      ...reconcile,
++      approvals: [
++        {
++          decisionId: 'awards:artifact-1::remove-artifact',
++          approvedAction: 'approve-removal',
++        },
++      ],
++      unresolvedBlockingCount: 2,
++    };
++    render(
++      <ImportCandidateReconcilePanel importId="imp-1" reconcile={withSavedApproval} onSaved={vi.fn()} />,
++    );
++    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div');
++    expect(artifactCard?.textContent).toContain('saved');
++  });
++
+   it('submits approvals to API', async () => {
+     const fetchMock = vi.fn().mockResolvedValue({
+       ok: true,
+diff --git a/src/tests/imports/importCandidateReviewWorkflow.test.ts b/src/tests/imports/importCandidateReviewWorkflow.test.ts
+index 07ff401..9442da5 100644
+--- a/src/tests/imports/importCandidateReviewWorkflow.test.ts
++++ b/src/tests/imports/importCandidateReviewWorkflow.test.ts
+@@ -39,13 +39,16 @@ import {
+   generateImportReviewManifest,
+   summarizeReviewManifestForAudit,
+ } from '@/server/imports/importCandidateReview/generate';
++import { loadImportReviewStateFromRow } from '@/server/imports/importCandidateReview/reconcile';
+ import { computeImportReviewManifestRevision } from '@/server/imports/importCandidateReview/revision';
+ import {
+   saveImportReviewApprovals,
++  importStatusAcceptsReviewApprovalUpdates,
+ } from '@/server/imports/importCandidateReview/service';
+ import {
+   parseStoredReviewApprovals,
+   parseStoredReviewManifest,
++  storedReviewManifestEnvelopeSchema,
+   toStoredApprovalsEnvelope,
+ } from '@/server/imports/importCandidateReview/storageSchema';
+ import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
+@@ -94,8 +97,9 @@ describe('import candidate review storage', () => {
+       candidate,
+     });
+     const decision = manifest.decisions.find((d) => d.action === 'manual-review');
++    expect(decision).toBeDefined();
+     if (!decision) {
+-      return;
++      throw new Error('Expected at least one manual-review decision for this fixture.');
+     }
+     vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
+       id: IMPORT_ID,
+@@ -126,8 +130,9 @@ describe('import candidate review storage', () => {
+     const decision = manifest.decisions.find(
+       (d) => d.section === 'publications' && d.action === 'manual-review',
+     );
++    expect(decision).toBeDefined();
+     if (!decision) {
+-      return;
++      throw new Error('Expected a publications manual-review decision for this fixture.');
+     }
+     const approvalsEnvelope = toStoredApprovalsEnvelope({
+       manifestRevision: envelope.manifestRevision,
+@@ -246,6 +251,133 @@ describe('import candidate review storage', () => {
+     expect(parseStoredReviewApprovals(approvals)?.manifestRevision).toBe(revisionA);
+   });
+ 
++  it('rejects duplicate decisionId values in stored manifest envelope', async () => {
++    const candidate = minimalImportDetails();
++    const payload = envelopeFromDetails(candidate);
++    const { envelope, manifest } = await generateImportReviewManifest({
++      importId: IMPORT_ID,
++      sourceFileName: 'cv.docx',
++      sourceTextHash: payload.sourceTextHash,
++      candidate,
++    });
++    expect(manifest.decisions.length).toBeGreaterThan(0);
++    const duplicateDecision = { ...manifest.decisions[0]! };
++    const malformed = {
++      ...envelope,
++      manifest: {
++        ...manifest,
++        decisions: [...manifest.decisions, duplicateDecision],
++      },
++    };
++    expect(parseStoredReviewManifest(malformed)).toBeNull();
++  });
++
++  it('accepts unique decisionId values in stored manifest envelope', async () => {
++    const candidate = minimalImportDetails();
++    const payload = envelopeFromDetails(candidate);
++    const { envelope } = await generateImportReviewManifest({
++      importId: IMPORT_ID,
++      sourceFileName: 'cv.docx',
++      sourceTextHash: payload.sourceTextHash,
++      candidate,
++    });
++    expect(storedReviewManifestEnvelopeSchema.safeParse(envelope).success).toBe(true);
++  });
++
++  it('fails closed when stored approvals are malformed', async () => {
++    const candidate = minimalImportDetails();
++    const payload = envelopeFromDetails(candidate);
++    const { envelope } = await generateImportReviewManifest({
++      importId: IMPORT_ID,
++      sourceFileName: 'cv.docx',
++      sourceTextHash: payload.sourceTextHash,
++      candidate,
++    });
++    expect(() =>
++      loadImportReviewStateFromRow({
++        reviewManifest: envelope,
++        reviewApprovals: { not: 'valid' },
++      }),
++    ).toThrowError(expect.objectContaining({ code: 'REVIEW_APPROVALS_INVALID' }));
++  });
++
++  it('rejects approval save when import status flips to finalized inside transaction', async () => {
++    const candidate = minimalImportDetails();
++    const payload = envelopeFromDetails(candidate);
++    const { envelope, manifest } = await generateImportReviewManifest({
++      importId: IMPORT_ID,
++      sourceFileName: 'cv.docx',
++      sourceTextHash: payload.sourceTextHash,
++      candidate,
++    });
++    const decision = manifest.decisions.find(
++      (d) => d.section === 'publications' && d.action === 'manual-review',
++    );
++    expect(decision).toBeDefined();
++    if (!decision) {
++      throw new Error('Expected a publications manual-review decision for this fixture.');
++    }
++
++    vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
++      id: IMPORT_ID,
++      status: 'PARSED',
++      candidatePayload: payload,
++      reviewManifest: envelope,
++      reviewApprovals: null,
++    } as never);
++
++    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
++      const tx = {
++        contentImport: {
++          findUnique: vi.fn().mockResolvedValue({
++            id: IMPORT_ID,
++            status: 'MERGED',
++            candidatePayload: payload,
++            reviewManifest: envelope,
++            reviewApprovals: null,
++          }),
++          update: vi.fn(),
++        },
++      };
++      return fn(tx as never);
++    });
++
++    await expect(
++      saveImportReviewApprovals({
++        importId: IMPORT_ID,
++        manifestRevision: envelope.manifestRevision,
++        approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
++      }),
++    ).rejects.toMatchObject({ code: 'IMPORT_FINALIZED' });
++  });
++
++  it('documents allowed import statuses for review approval updates', () => {
++    expect(importStatusAcceptsReviewApprovalUpdates('PARSED')).toBe(true);
++    expect(importStatusAcceptsReviewApprovalUpdates('NEEDS_REVIEW')).toBe(true);
++    expect(importStatusAcceptsReviewApprovalUpdates('MERGED')).toBe(false);
++    expect(importStatusAcceptsReviewApprovalUpdates('REJECTED')).toBe(false);
++    expect(importStatusAcceptsReviewApprovalUpdates('FAILED')).toBe(false);
++    expect(importStatusAcceptsReviewApprovalUpdates('UPLOADED')).toBe(false);
++  });
++
++  it('uses unambiguous revision serialization for unusual decision ids', () => {
++    const hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
++    const revisionA = computeImportReviewManifestRevision({
++      sourceTextHash: hash,
++      decisionIds: ['id\nb', 'id'],
++    });
++    const revisionB = computeImportReviewManifestRevision({
++      sourceTextHash: hash,
++      decisionIds: ['id', 'id\nb'],
++    });
++    const revisionC = computeImportReviewManifestRevision({
++      sourceTextHash: hash,
++      decisionIds: ['id', 'idb'],
++    });
++    expect(revisionA).toBe(revisionB);
++    expect(revisionA).not.toBe(revisionC);
++  });
++
+   it('advisory patent decisions do not block merge accounting count', async () => {
+     const baseline = assertSiteContent(SITE_CONTENT_RAW);
+     const candidate = minimalImportDetails({
+diff --git a/src/tests/imports/importsDomain.test.ts b/src/tests/imports/importsDomain.test.ts
+index 5be36e8..30589a5 100644
+--- a/src/tests/imports/importsDomain.test.ts
++++ b/src/tests/imports/importsDomain.test.ts
+@@ -129,6 +129,7 @@ describe('importsDomain', () => {
+       rawHtmlTruncated: false,
+     });
+     expect(detail.candidateReview).toBeNull();
++    expect(detail.candidateReconcileReview).toBeNull();
+   });
+ 
+   it('toImportDetail has null candidateReview for malformed candidatePayload', () => {
+@@ -162,6 +163,7 @@ describe('importsDomain', () => {
+     const detail = toImportDetail(row);
+     expect(detail.candidateReview).toBeNull();
+     expect(detail.candidateSummary).toBeNull();
++    expect(detail.candidateReconcileReview).toBeNull();
+   });
+ 
+   it('toImportDetail includes candidateReview for envelope payloads', () => {
+@@ -215,6 +217,7 @@ describe('importsDomain', () => {
+     const patentEntry = detail.candidateReview!.countValidation.entries.find((e) => e.code === 'PATENT_COUNT_MISMATCH');
+     expect(patentEntry).toBeDefined();
+     expect(patentEntry!.severity).toBe('warning');
++    expect(detail.candidateReconcileReview).toBeNull();
+   });
+ });
+ 
+diff --git a/src/tests/imports/mergeImportToDraft.test.ts b/src/tests/imports/mergeImportToDraft.test.ts
+index e2285e2..a1babad 100644
+--- a/src/tests/imports/mergeImportToDraft.test.ts
++++ b/src/tests/imports/mergeImportToDraft.test.ts
+@@ -35,6 +35,7 @@ vi.mock('@/server/imports/importCandidateReview/service', () => ({
+ 
+ import { SITE_CONTENT_RAW } from '@/content/defaults';
+ import { assertSiteContent, validateSiteContent } from '@/content/validators';
++import { recordContentEvent } from '@/server/content/contentEvents';
+ import { getWorkingDraft } from '@/server/content/contentWorkflowCore';
+ import { prisma } from '@/server/db/prisma';
+ import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
+@@ -62,6 +63,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
+     details: ReturnType<typeof minimalImportDetails>,
+     importId: string,
+     rawDocumentText = 'body',
++    options?: { resolveBlocking?: boolean },
+   ) {
+     const envelope = buildImportCandidatePayload({
+       rawDocumentText,
+@@ -80,7 +82,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
+       .filter((d) => (d.action === 'manual-review' || d.action === 'remove-artifact') && d.section !== 'patents' && d.section !== 'research')
+       .map((d) => ({ decisionId: d.decisionId, approvedAction: 'skip' as const }));
+     const approvalsEnvelope =
+-      blockingApprovals.length > 0
++      options?.resolveBlocking !== false && blockingApprovals.length > 0
+         ? toStoredApprovalsEnvelope({
+             manifestRevision: reviewEnvelope.manifestRevision,
+             approvals: blockingApprovals,
+@@ -477,4 +479,176 @@ describe('mergeImportCandidateToWorkingDraft', () => {
+       expect(validated.data.patents.items).toHaveLength(5);
+     }
+   });
++
++  it('rejects unresolved review override when reason is shorter than 8 characters', async () => {
++    const details = minimalImportDetails();
++    const row = await attachReviewManifest(
++      {
++        id: 'imp-short-reason',
++        status: 'PARSED',
++        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
++        createdAt: new Date(),
++        versions: [],
++      },
++      details,
++      'imp-short-reason',
++      'body',
++      { resolveBlocking: false },
++    );
++    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
++    vi.mocked(getWorkingDraft).mockResolvedValue(null);
++
++    await expect(
++      mergeImportCandidateToWorkingDraft({
++        importId: 'imp-short-reason',
++        action: 'create',
++        acknowledgeUnresolvedReview: true,
++        unresolvedReviewReason: 'short',
++      }),
++    ).rejects.toMatchObject({ code: 'MERGE_ACK_REQUIRED' });
++    expect(prisma.contentVersion.create).not.toHaveBeenCalled();
++  });
++
++  it('does not record override audit event when merge fails after acknowledgement', async () => {
++    vi.mocked(recordContentEvent).mockClear();
++    const details = minimalImportDetails();
++    const row = await attachReviewManifest(
++      {
++        id: 'imp-fail-merge',
++        status: 'PARSED',
++        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
++        createdAt: new Date(),
++        versions: [],
++      },
++      details,
++      'imp-fail-merge',
++      'body',
++      { resolveBlocking: false },
++    );
++    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
++    vi.mocked(getWorkingDraft).mockResolvedValue(null);
++    vi.mocked(prisma.contentVersion.create).mockRejectedValue(new Error('db failure'));
++
++    await expect(
++      mergeImportCandidateToWorkingDraft({
++        importId: 'imp-fail-merge',
++        action: 'create',
++        acknowledgeUnresolvedReview: true,
++        unresolvedReviewReason: 'Accepted risk for unresolved reconciliation decisions.',
++      }),
++    ).rejects.toThrow('db failure');
++
++    const overrideEvents = vi
++      .mocked(recordContentEvent)
++      .mock.calls.filter(
++        (call) =>
++          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
++          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
++      );
++    expect(overrideEvents).toHaveLength(0);
++  });
++
++  it('records exactly one override audit event after successful acknowledged merge', async () => {
++    vi.mocked(recordContentEvent).mockClear();
++    const details = minimalImportDetails();
++    const row = await attachReviewManifest(
++      {
++        id: 'imp-override-ok',
++        status: 'PARSED',
++        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
++        createdAt: new Date(),
++        versions: [],
++      },
++      details,
++      'imp-override-ok',
++      'body',
++      { resolveBlocking: false },
++    );
++    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
++    vi.mocked(getWorkingDraft).mockResolvedValue(null);
++    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
++      id: 'cv-override',
++      status: 'DRAFT',
++      draftSlot: 'main',
++      importId: 'imp-override-ok',
++      payload: {},
++      label: null,
++      changeSummary: null,
++      createdBy: null,
++      createdAt: new Date(),
++      updatedAt: new Date(),
++      publishedAt: null,
++      publishSequence: null,
++    } as never);
++
++    await mergeImportCandidateToWorkingDraft({
++      importId: 'imp-override-ok',
++      action: 'create',
++      acknowledgeUnresolvedReview: true,
++      unresolvedReviewReason: '  Accepted risk for unresolved reconciliation decisions.  ',
++    });
++
++    const overrideEvents = vi
++      .mocked(recordContentEvent)
++      .mock.calls.filter(
++        (call) =>
++          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
++          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
++      );
++    expect(overrideEvents).toHaveLength(1);
++    expect(overrideEvents[0]?.[0]).toMatchObject({
++      versionId: 'cv-override',
++      payload: expect.objectContaining({
++        reason: 'Accepted risk for unresolved reconciliation decisions.',
++      }),
++    });
++  });
++
++  it('does not record override audit event when unresolved blocking count is zero', async () => {
++    vi.mocked(recordContentEvent).mockClear();
++    const details = minimalImportDetails();
++    const row = await attachReviewManifest(
++      {
++        id: 'imp-no-override',
++        status: 'PARSED',
++        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
++        createdAt: new Date(),
++        versions: [],
++      },
++      details,
++      'imp-no-override',
++    );
++    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
++    vi.mocked(getWorkingDraft).mockResolvedValue(null);
++    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
++      id: 'cv-no-override',
++      status: 'DRAFT',
++      draftSlot: 'main',
++      importId: 'imp-no-override',
++      payload: {},
++      label: null,
++      changeSummary: null,
++      createdBy: null,
++      createdAt: new Date(),
++      updatedAt: new Date(),
++      publishedAt: null,
++      publishSequence: null,
++    } as never);
++
++    await mergeImportCandidateToWorkingDraft({
++      importId: 'imp-no-override',
++      action: 'create',
++      acknowledgeUnresolvedReview: true,
++      unresolvedReviewReason: 'Should not be used when nothing is unresolved.',
++    });
++
++    const overrideEvents = vi
++      .mocked(recordContentEvent)
++      .mock.calls.filter(
++        (call) =>
++          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
++          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
++      );
++    expect(overrideEvents).toHaveLength(0);
++  });
+ });

--- a/changes.diff
+++ b/changes.diff
@@ -1,627 +1,1327 @@
-﻿diff --git a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
-index 8674868..49ca33c 100644
+﻿diff --git a/changes.diff b/changes.diff
+index 9a28781..e69de29 100644
+--- a/changes.diff
++++ b/changes.diff
+@@ -1,937 +0,0 @@
+-´╗┐diff --git a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+-index 8674868..49ca33c 100644
+---- a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+-+++ b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+-@@ -154,6 +154,29 @@ function decisionControls(
+-   );
+- }
+- 
+-+function approvalBadgeStatus(
+-+  draftApproval: LocalApproval | undefined,
+-+  serverApproval: LocalApproval | undefined,
+-+): 'pending' | 'unsaved' | 'saved' {
+-+  if (draftApproval) {
+-+    return 'unsaved';
+-+  }
+-+  if (serverApproval) {
+-+    return 'saved';
+-+  }
+-+  return 'pending';
+-+}
+-+
+-+function ApprovalStatusBadge({ status }: { status: 'pending' | 'unsaved' | 'saved' }) {
+-+  if (status === 'saved') {
+-+    return <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>;
+-+  }
+-+  if (status === 'unsaved') {
+-+    return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">unsaved</span>;
+-+  }
+-+  return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>;
+-+}
+-+
+- export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }: Props) {
+-   const [draftApprovals, setDraftApprovals] = useState<LocalApproval[]>([]);
+-   const [saving, setSaving] = useState(false);
+-@@ -308,23 +331,22 @@ export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }:
+-           <h3 className="text-sm font-medium text-foreground">{sectionLabel(section)}</h3>
+-           <div className="space-y-3">
+-             {decisions.map((decision) => {
+-+              const serverApproval = serverApprovals.find((a) => a.decisionId === decision.decisionId);
+-+              const draftApproval = draftApprovals.find((a) => a.decisionId === decision.decisionId);
+-               const current = effectiveApprovals.get(decision.decisionId);
+--              const isCluster = Boolean(decision.relatedExistingIds && decision.relatedExistingIds.length > 0);
+--              const clusterMembers = isCluster
+--                ? [decision.existingId!, ...(decision.relatedExistingIds ?? [])]
+--                : [];
+--              const resolved = Boolean(current);
+-+              const clusterMemberIds = [decision.existingId, ...(decision.relatedExistingIds ?? [])].filter(
+-+                (id): id is string => Boolean(id),
+-+              );
+-+              const isCluster = clusterMemberIds.length >= 2;
+-+              const clusterMembers = isCluster ? clusterMemberIds : [];
+-+              const approvalStatus = approvalBadgeStatus(draftApproval, serverApproval as LocalApproval | undefined);
+- 
+-               return (
+-                 <div key={decision.decisionId} className="rounded border border-primary/15 p-3 text-xs space-y-2">
+-                   <div className="flex flex-wrap items-center gap-2">
+-                     <span className="font-medium text-foreground">{decision.action}</span>
+-                     <span className="text-muted">confidence: {decision.confidence}</span>
+--                    {resolved ? (
+--                      <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>
+--                    ) : (
+--                      <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>
+--                    )}
+-+                    <ApprovalStatusBadge status={approvalStatus} />
+-                   </div>
+-                   <p className="text-foreground">{decision.reason}</p>
+-                   {decision.existingId ? (
+-diff --git a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
+-index dbb13af..3dbecca 100644
+---- a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
+-+++ b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
+-@@ -38,7 +38,8 @@ function mergeErrorResponse(e: ImportMergeError): NextResponse {
+-     e.code === 'REVIEW_BLOCKED' ||
+-     e.code === 'REVIEW_MANIFEST_MISSING' ||
+-     e.code === 'REVIEW_MANIFEST_STALE' ||
+--    e.code === 'REVIEW_APPROVALS_STALE'
+-+    e.code === 'REVIEW_APPROVALS_STALE' ||
+-+    e.code === 'REVIEW_APPROVALS_INVALID'
+-   ) {
+-     status = 422;
+-   }
+-diff --git a/src/server/imports/importCandidateReview/reconcile.ts b/src/server/imports/importCandidateReview/reconcile.ts
+-index 50c12d9..a714662 100644
+---- a/src/server/imports/importCandidateReview/reconcile.ts
+-+++ b/src/server/imports/importCandidateReview/reconcile.ts
+-@@ -48,15 +48,25 @@ export type LoadedImportReviewState = {
+- export function loadImportReviewStateFromRow(row: {
+-   reviewManifest: unknown;
+-   reviewApprovals: unknown;
+--  candidatePayload: unknown;
+- }): LoadedImportReviewState | null {
+-   const manifestEnvelope = parseStoredReviewManifest(row.reviewManifest);
+-   if (!manifestEnvelope) {
+-     return null;
+-   }
+--  const approvalsEnvelope = row.reviewApprovals
+--    ? parseStoredReviewApprovals(row.reviewApprovals)
+--    : null;
+-+  const approvalsEnvelope =
+-+    row.reviewApprovals === null || row.reviewApprovals === undefined
+-+      ? null
+-+      : parseStoredReviewApprovals(row.reviewApprovals);
+-+  if (
+-+    row.reviewApprovals !== null &&
+-+    row.reviewApprovals !== undefined &&
+-+    approvalsEnvelope === null
+-+  ) {
+-+    throw new ImportReviewReconcileError(
+-+      'REVIEW_APPROVALS_INVALID',
+-+      'Stored review approvals are malformed.',
+-+    );
+-+  }
+-   const approvals = approvalsEnvelope?.approvals ?? [];
+-   let manifest = manifestEnvelope.manifest as CandidateReviewManifest;
+-   if (approvals.length > 0) {
+-diff --git a/src/server/imports/importCandidateReview/revision.ts b/src/server/imports/importCandidateReview/revision.ts
+-index 0d19e82..15a741e 100644
+---- a/src/server/imports/importCandidateReview/revision.ts
+-+++ b/src/server/imports/importCandidateReview/revision.ts
+-@@ -7,7 +7,10 @@ export function computeImportReviewManifestRevision(input: {
+-   sourceTextHash: string;
+-   decisionIds: readonly string[];
+- }): string {
+--  const payload = `${input.sourceTextHash}\n${[...input.decisionIds].sort().join('\n')}`;
+-+  const payload = JSON.stringify({
+-+    sourceTextHash: input.sourceTextHash,
+-+    decisionIds: [...input.decisionIds].sort(),
+-+  });
+-   return createHash('sha256').update(payload).digest('hex').slice(0, 32);
+- }
+- 
+-diff --git a/src/server/imports/importCandidateReview/service.ts b/src/server/imports/importCandidateReview/service.ts
+-index 74008de..3b449d4 100644
+---- a/src/server/imports/importCandidateReview/service.ts
+-+++ b/src/server/imports/importCandidateReview/service.ts
+-@@ -1,5 +1,6 @@
+- import 'server-only';
+- 
+-+import type { ImportStatus } from '@prisma/client';
+- import { Prisma } from '@prisma/client';
+- 
+- import { recordContentEvent } from '@/server/content/contentEvents';
+-@@ -28,6 +29,21 @@ import {
+- } from '@/server/imports/importCandidateReview/storageSchema';
+- import { ImportDomainError } from '@/server/imports/types';
+- 
+-+const REVIEW_APPROVAL_ALLOWED_STATUSES = new Set<ImportStatus>(['PARSED', 'NEEDS_REVIEW']);
+-+
+-+export function importStatusAcceptsReviewApprovalUpdates(status: ImportStatus): boolean {
+-+  return REVIEW_APPROVAL_ALLOWED_STATUSES.has(status);
+-+}
+-+
+-+function assertImportStatusAcceptsReviewApprovalUpdates(status: ImportStatus): void {
+-+  if (!importStatusAcceptsReviewApprovalUpdates(status)) {
+-+    throw new ImportReviewApprovalPersistError(
+-+      'IMPORT_FINALIZED',
+-+      `Import status "${status}" does not accept review approval updates.`,
+-+    );
+-+  }
+-+}
+-+
+- export class ImportReviewApprovalPersistError extends Error {
+-   constructor(
+-     readonly code:
+-@@ -137,14 +153,17 @@ export async function saveImportReviewApprovals(input: {
+-   if (!row) {
+-     throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
+-   }
+--  if (row.status === 'REJECTED' || row.status === 'FAILED') {
+--    throw new ImportReviewApprovalPersistError(
+--      'IMPORT_FINALIZED',
+--      `Import status "${row.status}" does not accept review approval updates.`,
+--    );
+--  }
+-+  assertImportStatusAcceptsReviewApprovalUpdates(row.status);
+- 
+--  const loaded = loadImportReviewStateFromRow(row);
+-+  let loaded: ReturnType<typeof loadImportReviewStateFromRow>;
+-+  try {
+-+    loaded = loadImportReviewStateFromRow(row);
+-+  } catch (e) {
+-+    if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
+-+      throw new ImportReviewApprovalPersistError('REVIEW_APPROVALS_INVALID', e.message);
+-+    }
+-+    throw e;
+-+  }
+-   if (!loaded) {
+-     throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
+-   }
+-@@ -175,6 +194,7 @@ export async function saveImportReviewApprovals(input: {
+-     if (!current) {
+-       throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
+-     }
+-+    assertImportStatusAcceptsReviewApprovalUpdates(current.status);
+-     const currentLoaded = loadImportReviewStateFromRow(current);
+-     if (!currentLoaded) {
+-       throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
+-diff --git a/src/server/imports/importCandidateReview/storageSchema.ts b/src/server/imports/importCandidateReview/storageSchema.ts
+-index 6d2052f..10c07f0 100644
+---- a/src/server/imports/importCandidateReview/storageSchema.ts
+-+++ b/src/server/imports/importCandidateReview/storageSchema.ts
+-@@ -60,23 +60,38 @@ const advisorySectionAccountingSchema = z.object({
+-   affectedRecordCount: z.number().int().nonnegative(),
+- });
+- 
+--const candidateReviewManifestSchema = z.object({
+--  generatedAt: z.string(),
+--  importId: z.string().nullable().optional(),
+--  importSource: z.string(),
+--  baseline: reviewBaselineRefSchema,
+--  decisions: z.array(reviewDecisionSchema),
+--  analysisAccounting: z.object({
+--    publications: reconciledSectionAccountingSchema,
+--    awards: reconciledSectionAccountingSchema,
+--  }),
+--  accounting: z.object({
+--    publications: reconciledSectionAccountingSchema,
+--    awards: reconciledSectionAccountingSchema,
+--    patents: advisorySectionAccountingSchema,
+--    research: advisorySectionAccountingSchema,
+--  }),
+--});
+-+const candidateReviewManifestSchema = z
+-+  .object({
+-+    generatedAt: z.string(),
+-+    importId: z.string().nullable().optional(),
+-+    importSource: z.string(),
+-+    baseline: reviewBaselineRefSchema,
+-+    decisions: z.array(reviewDecisionSchema),
+-+    analysisAccounting: z.object({
+-+      publications: reconciledSectionAccountingSchema,
+-+      awards: reconciledSectionAccountingSchema,
+-+    }),
+-+    accounting: z.object({
+-+      publications: reconciledSectionAccountingSchema,
+-+      awards: reconciledSectionAccountingSchema,
+-+      patents: advisorySectionAccountingSchema,
+-+      research: advisorySectionAccountingSchema,
+-+    }),
+-+  })
+-+  .superRefine((value, ctx) => {
+-+    const seen = new Set<string>();
+-+    value.decisions.forEach((d, idx) => {
+-+      if (seen.has(d.decisionId)) {
+-+        ctx.addIssue({
+-+          code: z.ZodIssueCode.custom,
+-+          path: ['decisions', idx, 'decisionId'],
+-+          message: 'decisionId must be unique within a manifest.',
+-+        });
+-+        return;
+-+      }
+-+      seen.add(d.decisionId);
+-+    });
+-+  });
+- 
+- export const storedReviewManifestEnvelopeSchema = z.object({
+-   storageVersion: z.literal(IMPORT_REVIEW_STORAGE_VERSION),
+-diff --git a/src/server/imports/mergeImportToDraft.ts b/src/server/imports/mergeImportToDraft.ts
+-index c79f927..d77ae32 100644
+---- a/src/server/imports/mergeImportToDraft.ts
+-+++ b/src/server/imports/mergeImportToDraft.ts
+-@@ -42,7 +42,8 @@ export class ImportMergeError extends Error {
+-       | 'REVIEW_BLOCKED'
+-       | 'REVIEW_MANIFEST_MISSING'
+-       | 'REVIEW_MANIFEST_STALE'
+--      | 'REVIEW_APPROVALS_STALE',
+-+      | 'REVIEW_APPROVALS_STALE'
+-+      | 'REVIEW_APPROVALS_INVALID',
+-     message: string,
+-   ) {
+-     super(message);
+-@@ -71,6 +72,50 @@ export type MergeImportCandidateResult = {
+-   alreadyMerged: boolean;
+- };
+- 
+-+async function recordSuccessfulMergeEvents(input: {
+-+  versionId: string;
+-+  importId: string;
+-+  action: 'create' | 'replace';
+-+  draftEventType: 'WORKING_DRAFT_CREATED' | 'WORKING_DRAFT_UPDATED';
+-+  draftEventPayload: Prisma.InputJsonValue;
+-+  reconciledAccounting: Prisma.InputJsonValue | null;
+-+  unresolvedBlockingCount: number;
+-+  acknowledgedUnresolvedReview: boolean;
+-+  normalizedUnresolvedReviewReason: string | null;
+-+}): Promise<void> {
+-+  await recordContentEvent({
+-+    eventType: input.draftEventType,
+-+    versionId: input.versionId,
+-+    payload: input.draftEventPayload,
+-+  });
+-+  await recordContentEvent({
+-+    eventType: 'SYSTEM_NOTE',
+-+    versionId: input.versionId,
+-+    payload: {
+-+      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+-+      importId: input.importId,
+-+      action: input.action,
+-+      reconciledAccounting: input.reconciledAccounting,
+-+      unresolvedBlockingCount: input.unresolvedBlockingCount,
+-+      acknowledgedUnresolvedReview: input.acknowledgedUnresolvedReview,
+-+      unresolvedReviewReason: input.normalizedUnresolvedReviewReason,
+-+    },
+-+  });
+-+  if (input.acknowledgedUnresolvedReview) {
+-+    await recordContentEvent({
+-+      eventType: 'SYSTEM_NOTE',
+-+      versionId: input.versionId,
+-+      payload: {
+-+        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+-+        importId: input.importId,
+-+        versionId: input.versionId,
+-+        unresolvedBlockingCount: input.unresolvedBlockingCount,
+-+        reason: input.normalizedUnresolvedReviewReason,
+-+      },
+-+    });
+-+  }
+-+}
+-+
+- /**
+-  * Creates a working draft from the import candidate, or replaces the existing draft payload.
+-  * Never touches published rows. Sets `ContentVersion.importId` and marks the import `MERGED`.
+-@@ -115,14 +160,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+-   const baselineData = basePayload.data;
+- 
+-   const manifestEnvelope = await ensureImportReviewManifest(input.importId);
+-+  // Reload after ensureImportReviewManifest ├ö├ç├Â it may have lazily generated and persisted a manifest.
+-   const reviewRow = await getContentImportDetail(input.importId);
+--  const loadedReview = reviewRow
+--    ? loadImportReviewStateFromRow({
+-+  let loadedReview: ReturnType<typeof loadImportReviewStateFromRow> = null;
+-+  if (reviewRow) {
+-+    try {
+-+      loadedReview = loadImportReviewStateFromRow({
+-         reviewManifest: reviewRow.reviewManifest,
+-         reviewApprovals: reviewRow.reviewApprovals,
+--        candidatePayload: reviewRow.candidatePayload,
+--      })
+--    : null;
+-+      });
+-+    } catch (e) {
+-+      if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
+-+        throw new ImportMergeError('REVIEW_APPROVALS_INVALID', e.message);
+-+      }
+-+      throw e;
+-+    }
+-+  }
+-   if (!loadedReview) {
+-     throw new ImportMergeError('REVIEW_MANIFEST_MISSING', 'Import has no reconciliation review manifest.');
+-   }
+-@@ -166,29 +219,19 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+-     throw e;
+-   }
+- 
+--  if (
+--    input.acknowledgeUnresolvedReview &&
+--    unresolvedBlockingCount > 0 &&
+--    !input.unresolvedReviewReason?.trim()
+--  ) {
+-+  const acknowledgedUnresolvedReview =
+-+    Boolean(input.acknowledgeUnresolvedReview) && unresolvedBlockingCount > 0;
+-+  const normalizedUnresolvedReviewReason = acknowledgedUnresolvedReview
+-+    ? (input.unresolvedReviewReason?.trim() ?? '')
+-+    : '';
+-+
+-+  if (acknowledgedUnresolvedReview && normalizedUnresolvedReviewReason.length < 8) {
+-     throw new ImportMergeError(
+-       'MERGE_ACK_REQUIRED',
+--      'Unresolved reconciliation override requires unresolvedReviewReason.',
+-+      'Unresolved reconciliation override requires unresolvedReviewReason of at least 8 characters.',
+-     );
+-   }
+- 
+--  if (input.acknowledgeUnresolvedReview && unresolvedBlockingCount > 0) {
+--    await recordContentEvent({
+--      eventType: 'SYSTEM_NOTE',
+--      payload: {
+--        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+--        importId: input.importId,
+--        unresolvedBlockingCount,
+--        reason: input.unresolvedReviewReason?.trim() ?? null,
+--      },
+--    });
+--  }
+--
+-   const provenance: ImportReviewProvenance = {
+-     importId: importRow.id,
+-     originalFileName: importRow.uploadedFile.originalName,
+-@@ -244,29 +287,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+-         createdBy: null,
+-       },
+-     });
+--    await recordContentEvent({
+--      eventType: 'WORKING_DRAFT_CREATED',
+-+    await recordSuccessfulMergeEvents({
+-       versionId: row.id,
+--      payload: {
+-+      importId: input.importId,
+-+      action: 'create',
+-+      draftEventType: 'WORKING_DRAFT_CREATED',
+-+      draftEventPayload: {
+-         importId: input.importId,
+-         source: 'import_candidate',
+-         reconciledAccounting,
+-         unresolvedBlockingCount,
+--        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+--      },
+--    });
+--    await recordContentEvent({
+--      eventType: 'SYSTEM_NOTE',
+--      versionId: row.id,
+--      payload: {
+--        kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+--        importId: input.importId,
+--        action: 'create',
+--        reconciledAccounting,
+--        unresolvedBlockingCount,
+--        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+--        unresolvedReviewReason: input.unresolvedReviewReason ?? null,
+-+        acknowledgedUnresolvedReview,
+-       },
+-+      reconciledAccounting,
+-+      unresolvedBlockingCount,
+-+      acknowledgedUnresolvedReview,
+-+      normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
+-     });
+-     await updateImportStatus(input.importId, 'MERGED');
+-     return { version: row, alreadyMerged: false };
+-@@ -283,29 +319,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
+-       changeSummary: input.changeSummary ?? working.changeSummary,
+-     },
+-   });
+--  await recordContentEvent({
+--    eventType: 'WORKING_DRAFT_UPDATED',
+-+  await recordSuccessfulMergeEvents({
+-     versionId: row.id,
+--    payload: {
+-+    importId: input.importId,
+-+    action: 'replace',
+-+    draftEventType: 'WORKING_DRAFT_UPDATED',
+-+    draftEventPayload: {
+-       importId: input.importId,
+-       source: 'import_candidate_replace',
+-       reconciledAccounting,
+-       unresolvedBlockingCount,
+--      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+--    },
+--  });
+--  await recordContentEvent({
+--    eventType: 'SYSTEM_NOTE',
+--    versionId: row.id,
+--    payload: {
+--      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+--      importId: input.importId,
+--      action: 'replace',
+--      reconciledAccounting,
+--      unresolvedBlockingCount,
+--      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+--      unresolvedReviewReason: input.unresolvedReviewReason ?? null,
+-+      acknowledgedUnresolvedReview,
+-     },
+-+    reconciledAccounting,
+-+    unresolvedBlockingCount,
+-+    acknowledgedUnresolvedReview,
+-+    normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
+-   });
+-   await updateImportStatus(input.importId, 'MERGED');
+-   return { version: row, alreadyMerged: false };
+-diff --git a/src/server/imports/serialize.ts b/src/server/imports/serialize.ts
+-index 170d65f..bc022ed 100644
+---- a/src/server/imports/serialize.ts
+-+++ b/src/server/imports/serialize.ts
+-@@ -144,7 +144,6 @@ export function buildImportCandidateReconcileReview(
+-   const loaded = loadImportReviewStateFromRow({
+-     reviewManifest: row.reviewManifest,
+-     reviewApprovals: row.reviewApprovals,
+--    candidatePayload: null,
+-   });
+-   if (!loaded) {
+-     return null;
+-diff --git a/src/tests/imports/importCandidateReconcilePanel.test.tsx b/src/tests/imports/importCandidateReconcilePanel.test.tsx
+-index 9cbd070..785a795 100644
+---- a/src/tests/imports/importCandidateReconcilePanel.test.tsx
+-+++ b/src/tests/imports/importCandidateReconcilePanel.test.tsx
+-@@ -1,6 +1,6 @@
+- /** @vitest-environment happy-dom */
+- 
+--import { fireEvent, render, screen } from '@testing-library/react';
+-+import { fireEvent, render, screen, within } from '@testing-library/react';
+- import { describe, expect, it, vi } from 'vitest';
+- 
+- import { ImportCandidateReconcilePanel } from '@/app/admin/imports/ImportCandidateReconcilePanel';
+-@@ -82,6 +82,33 @@ describe('ImportCandidateReconcilePanel', () => {
+-     expect(screen.getByRole('button', { name: /Remove entire cluster/i })).toBeTruthy();
+-   });
+- 
+-+  it('shows unsaved badge for local draft approval before save', () => {
+-+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={vi.fn()} />);
+-+    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div')!;
+-+    expect(artifactCard.textContent).toContain('pending');
+-+    fireEvent.click(within(artifactCard).getByRole('button', { name: /Approve removal/i }));
+-+    expect(artifactCard.textContent).toContain('unsaved');
+-+    expect(within(artifactCard).getByText('unsaved')).toBeTruthy();
+-+  });
+-+
+-+  it('shows saved badge for server-persisted approval', () => {
+-+    const withSavedApproval: ImportCandidateReconcileReviewModel = {
+-+      ...reconcile,
+-+      approvals: [
+-+        {
+-+          decisionId: 'awards:artifact-1::remove-artifact',
+-+          approvedAction: 'approve-removal',
+-+        },
+-+      ],
+-+      unresolvedBlockingCount: 2,
+-+    };
+-+    render(
+-+      <ImportCandidateReconcilePanel importId="imp-1" reconcile={withSavedApproval} onSaved={vi.fn()} />,
+-+    );
+-+    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div');
+-+    expect(artifactCard?.textContent).toContain('saved');
+-+  });
+-+
+-   it('submits approvals to API', async () => {
+-     const fetchMock = vi.fn().mockResolvedValue({
+-       ok: true,
+-diff --git a/src/tests/imports/importCandidateReviewWorkflow.test.ts b/src/tests/imports/importCandidateReviewWorkflow.test.ts
+-index 07ff401..9442da5 100644
+---- a/src/tests/imports/importCandidateReviewWorkflow.test.ts
+-+++ b/src/tests/imports/importCandidateReviewWorkflow.test.ts
+-@@ -39,13 +39,16 @@ import {
+-   generateImportReviewManifest,
+-   summarizeReviewManifestForAudit,
+- } from '@/server/imports/importCandidateReview/generate';
+-+import { loadImportReviewStateFromRow } from '@/server/imports/importCandidateReview/reconcile';
+- import { computeImportReviewManifestRevision } from '@/server/imports/importCandidateReview/revision';
+- import {
+-   saveImportReviewApprovals,
+-+  importStatusAcceptsReviewApprovalUpdates,
+- } from '@/server/imports/importCandidateReview/service';
+- import {
+-   parseStoredReviewApprovals,
+-   parseStoredReviewManifest,
+-+  storedReviewManifestEnvelopeSchema,
+-   toStoredApprovalsEnvelope,
+- } from '@/server/imports/importCandidateReview/storageSchema';
+- import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
+-@@ -94,8 +97,9 @@ describe('import candidate review storage', () => {
+-       candidate,
+-     });
+-     const decision = manifest.decisions.find((d) => d.action === 'manual-review');
+-+    expect(decision).toBeDefined();
+-     if (!decision) {
+--      return;
+-+      throw new Error('Expected at least one manual-review decision for this fixture.');
+-     }
+-     vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
+-       id: IMPORT_ID,
+-@@ -126,8 +130,9 @@ describe('import candidate review storage', () => {
+-     const decision = manifest.decisions.find(
+-       (d) => d.section === 'publications' && d.action === 'manual-review',
+-     );
+-+    expect(decision).toBeDefined();
+-     if (!decision) {
+--      return;
+-+      throw new Error('Expected a publications manual-review decision for this fixture.');
+-     }
+-     const approvalsEnvelope = toStoredApprovalsEnvelope({
+-       manifestRevision: envelope.manifestRevision,
+-@@ -246,6 +251,133 @@ describe('import candidate review storage', () => {
+-     expect(parseStoredReviewApprovals(approvals)?.manifestRevision).toBe(revisionA);
+-   });
+- 
+-+  it('rejects duplicate decisionId values in stored manifest envelope', async () => {
+-+    const candidate = minimalImportDetails();
+-+    const payload = envelopeFromDetails(candidate);
+-+    const { envelope, manifest } = await generateImportReviewManifest({
+-+      importId: IMPORT_ID,
+-+      sourceFileName: 'cv.docx',
+-+      sourceTextHash: payload.sourceTextHash,
+-+      candidate,
+-+    });
+-+    expect(manifest.decisions.length).toBeGreaterThan(0);
+-+    const duplicateDecision = { ...manifest.decisions[0]! };
+-+    const malformed = {
+-+      ...envelope,
+-+      manifest: {
+-+        ...manifest,
+-+        decisions: [...manifest.decisions, duplicateDecision],
+-+      },
+-+    };
+-+    expect(parseStoredReviewManifest(malformed)).toBeNull();
+-+  });
+-+
+-+  it('accepts unique decisionId values in stored manifest envelope', async () => {
+-+    const candidate = minimalImportDetails();
+-+    const payload = envelopeFromDetails(candidate);
+-+    const { envelope } = await generateImportReviewManifest({
+-+      importId: IMPORT_ID,
+-+      sourceFileName: 'cv.docx',
+-+      sourceTextHash: payload.sourceTextHash,
+-+      candidate,
+-+    });
+-+    expect(storedReviewManifestEnvelopeSchema.safeParse(envelope).success).toBe(true);
+-+  });
+-+
+-+  it('fails closed when stored approvals are malformed', async () => {
+-+    const candidate = minimalImportDetails();
+-+    const payload = envelopeFromDetails(candidate);
+-+    const { envelope } = await generateImportReviewManifest({
+-+      importId: IMPORT_ID,
+-+      sourceFileName: 'cv.docx',
+-+      sourceTextHash: payload.sourceTextHash,
+-+      candidate,
+-+    });
+-+    expect(() =>
+-+      loadImportReviewStateFromRow({
+-+        reviewManifest: envelope,
+-+        reviewApprovals: { not: 'valid' },
+-+      }),
+-+    ).toThrowError(expect.objectContaining({ code: 'REVIEW_APPROVALS_INVALID' }));
+-+  });
+-+
+-+  it('rejects approval save when import status flips to finalized inside transaction', async () => {
+-+    const candidate = minimalImportDetails();
+-+    const payload = envelopeFromDetails(candidate);
+-+    const { envelope, manifest } = await generateImportReviewManifest({
+-+      importId: IMPORT_ID,
+-+      sourceFileName: 'cv.docx',
+-+      sourceTextHash: payload.sourceTextHash,
+-+      candidate,
+-+    });
+-+    const decision = manifest.decisions.find(
+-+      (d) => d.section === 'publications' && d.action === 'manual-review',
+-+    );
+-+    expect(decision).toBeDefined();
+-+    if (!decision) {
+-+      throw new Error('Expected a publications manual-review decision for this fixture.');
+-+    }
+-+
+-+    vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
+-+      id: IMPORT_ID,
+-+      status: 'PARSED',
+-+      candidatePayload: payload,
+-+      reviewManifest: envelope,
+-+      reviewApprovals: null,
+-+    } as never);
+-+
+-+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
+-+      const tx = {
+-+        contentImport: {
+-+          findUnique: vi.fn().mockResolvedValue({
+-+            id: IMPORT_ID,
+-+            status: 'MERGED',
+-+            candidatePayload: payload,
+-+            reviewManifest: envelope,
+-+            reviewApprovals: null,
+-+          }),
+-+          update: vi.fn(),
+-+        },
+-+      };
+-+      return fn(tx as never);
+-+    });
+-+
+-+    await expect(
+-+      saveImportReviewApprovals({
+-+        importId: IMPORT_ID,
+-+        manifestRevision: envelope.manifestRevision,
+-+        approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+-+      }),
+-+    ).rejects.toMatchObject({ code: 'IMPORT_FINALIZED' });
+-+  });
+-+
+-+  it('documents allowed import statuses for review approval updates', () => {
+-+    expect(importStatusAcceptsReviewApprovalUpdates('PARSED')).toBe(true);
+-+    expect(importStatusAcceptsReviewApprovalUpdates('NEEDS_REVIEW')).toBe(true);
+-+    expect(importStatusAcceptsReviewApprovalUpdates('MERGED')).toBe(false);
+-+    expect(importStatusAcceptsReviewApprovalUpdates('REJECTED')).toBe(false);
+-+    expect(importStatusAcceptsReviewApprovalUpdates('FAILED')).toBe(false);
+-+    expect(importStatusAcceptsReviewApprovalUpdates('UPLOADED')).toBe(false);
+-+  });
+-+
+-+  it('uses unambiguous revision serialization for unusual decision ids', () => {
+-+    const hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+-+    const revisionA = computeImportReviewManifestRevision({
+-+      sourceTextHash: hash,
+-+      decisionIds: ['id\nb', 'id'],
+-+    });
+-+    const revisionB = computeImportReviewManifestRevision({
+-+      sourceTextHash: hash,
+-+      decisionIds: ['id', 'id\nb'],
+-+    });
+-+    const revisionC = computeImportReviewManifestRevision({
+-+      sourceTextHash: hash,
+-+      decisionIds: ['id', 'idb'],
+-+    });
+-+    expect(revisionA).toBe(revisionB);
+-+    expect(revisionA).not.toBe(revisionC);
+-+  });
+-+
+-   it('advisory patent decisions do not block merge accounting count', async () => {
+-     const baseline = assertSiteContent(SITE_CONTENT_RAW);
+-     const candidate = minimalImportDetails({
+-diff --git a/src/tests/imports/importsDomain.test.ts b/src/tests/imports/importsDomain.test.ts
+-index 5be36e8..30589a5 100644
+---- a/src/tests/imports/importsDomain.test.ts
+-+++ b/src/tests/imports/importsDomain.test.ts
+-@@ -129,6 +129,7 @@ describe('importsDomain', () => {
+-       rawHtmlTruncated: false,
+-     });
+-     expect(detail.candidateReview).toBeNull();
+-+    expect(detail.candidateReconcileReview).toBeNull();
+-   });
+- 
+-   it('toImportDetail has null candidateReview for malformed candidatePayload', () => {
+-@@ -162,6 +163,7 @@ describe('importsDomain', () => {
+-     const detail = toImportDetail(row);
+-     expect(detail.candidateReview).toBeNull();
+-     expect(detail.candidateSummary).toBeNull();
+-+    expect(detail.candidateReconcileReview).toBeNull();
+-   });
+- 
+-   it('toImportDetail includes candidateReview for envelope payloads', () => {
+-@@ -215,6 +217,7 @@ describe('importsDomain', () => {
+-     const patentEntry = detail.candidateReview!.countValidation.entries.find((e) => e.code === 'PATENT_COUNT_MISMATCH');
+-     expect(patentEntry).toBeDefined();
+-     expect(patentEntry!.severity).toBe('warning');
+-+    expect(detail.candidateReconcileReview).toBeNull();
+-   });
+- });
+- 
+-diff --git a/src/tests/imports/mergeImportToDraft.test.ts b/src/tests/imports/mergeImportToDraft.test.ts
+-index e2285e2..a1babad 100644
+---- a/src/tests/imports/mergeImportToDraft.test.ts
+-+++ b/src/tests/imports/mergeImportToDraft.test.ts
+-@@ -35,6 +35,7 @@ vi.mock('@/server/imports/importCandidateReview/service', () => ({
+- 
+- import { SITE_CONTENT_RAW } from '@/content/defaults';
+- import { assertSiteContent, validateSiteContent } from '@/content/validators';
+-+import { recordContentEvent } from '@/server/content/contentEvents';
+- import { getWorkingDraft } from '@/server/content/contentWorkflowCore';
+- import { prisma } from '@/server/db/prisma';
+- import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
+-@@ -62,6 +63,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
+-     details: ReturnType<typeof minimalImportDetails>,
+-     importId: string,
+-     rawDocumentText = 'body',
+-+    options?: { resolveBlocking?: boolean },
+-   ) {
+-     const envelope = buildImportCandidatePayload({
+-       rawDocumentText,
+-@@ -80,7 +82,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
+-       .filter((d) => (d.action === 'manual-review' || d.action === 'remove-artifact') && d.section !== 'patents' && d.section !== 'research')
+-       .map((d) => ({ decisionId: d.decisionId, approvedAction: 'skip' as const }));
+-     const approvalsEnvelope =
+--      blockingApprovals.length > 0
+-+      options?.resolveBlocking !== false && blockingApprovals.length > 0
+-         ? toStoredApprovalsEnvelope({
+-             manifestRevision: reviewEnvelope.manifestRevision,
+-             approvals: blockingApprovals,
+-@@ -477,4 +479,176 @@ describe('mergeImportCandidateToWorkingDraft', () => {
+-       expect(validated.data.patents.items).toHaveLength(5);
+-     }
+-   });
+-+
+-+  it('rejects unresolved review override when reason is shorter than 8 characters', async () => {
+-+    const details = minimalImportDetails();
+-+    const row = await attachReviewManifest(
+-+      {
+-+        id: 'imp-short-reason',
+-+        status: 'PARSED',
+-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+-+        createdAt: new Date(),
+-+        versions: [],
+-+      },
+-+      details,
+-+      'imp-short-reason',
+-+      'body',
+-+      { resolveBlocking: false },
+-+    );
+-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+-+
+-+    await expect(
+-+      mergeImportCandidateToWorkingDraft({
+-+        importId: 'imp-short-reason',
+-+        action: 'create',
+-+        acknowledgeUnresolvedReview: true,
+-+        unresolvedReviewReason: 'short',
+-+      }),
+-+    ).rejects.toMatchObject({ code: 'MERGE_ACK_REQUIRED' });
+-+    expect(prisma.contentVersion.create).not.toHaveBeenCalled();
+-+  });
+-+
+-+  it('does not record override audit event when merge fails after acknowledgement', async () => {
+-+    vi.mocked(recordContentEvent).mockClear();
+-+    const details = minimalImportDetails();
+-+    const row = await attachReviewManifest(
+-+      {
+-+        id: 'imp-fail-merge',
+-+        status: 'PARSED',
+-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+-+        createdAt: new Date(),
+-+        versions: [],
+-+      },
+-+      details,
+-+      'imp-fail-merge',
+-+      'body',
+-+      { resolveBlocking: false },
+-+    );
+-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+-+    vi.mocked(prisma.contentVersion.create).mockRejectedValue(new Error('db failure'));
+-+
+-+    await expect(
+-+      mergeImportCandidateToWorkingDraft({
+-+        importId: 'imp-fail-merge',
+-+        action: 'create',
+-+        acknowledgeUnresolvedReview: true,
+-+        unresolvedReviewReason: 'Accepted risk for unresolved reconciliation decisions.',
+-+      }),
+-+    ).rejects.toThrow('db failure');
+-+
+-+    const overrideEvents = vi
+-+      .mocked(recordContentEvent)
+-+      .mock.calls.filter(
+-+        (call) =>
+-+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
+-+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+-+      );
+-+    expect(overrideEvents).toHaveLength(0);
+-+  });
+-+
+-+  it('records exactly one override audit event after successful acknowledged merge', async () => {
+-+    vi.mocked(recordContentEvent).mockClear();
+-+    const details = minimalImportDetails();
+-+    const row = await attachReviewManifest(
+-+      {
+-+        id: 'imp-override-ok',
+-+        status: 'PARSED',
+-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+-+        createdAt: new Date(),
+-+        versions: [],
+-+      },
+-+      details,
+-+      'imp-override-ok',
+-+      'body',
+-+      { resolveBlocking: false },
+-+    );
+-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+-+    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
+-+      id: 'cv-override',
+-+      status: 'DRAFT',
+-+      draftSlot: 'main',
+-+      importId: 'imp-override-ok',
+-+      payload: {},
+-+      label: null,
+-+      changeSummary: null,
+-+      createdBy: null,
+-+      createdAt: new Date(),
+-+      updatedAt: new Date(),
+-+      publishedAt: null,
+-+      publishSequence: null,
+-+    } as never);
+-+
+-+    await mergeImportCandidateToWorkingDraft({
+-+      importId: 'imp-override-ok',
+-+      action: 'create',
+-+      acknowledgeUnresolvedReview: true,
+-+      unresolvedReviewReason: '  Accepted risk for unresolved reconciliation decisions.  ',
+-+    });
+-+
+-+    const overrideEvents = vi
+-+      .mocked(recordContentEvent)
+-+      .mock.calls.filter(
+-+        (call) =>
+-+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
+-+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+-+      );
+-+    expect(overrideEvents).toHaveLength(1);
+-+    expect(overrideEvents[0]?.[0]).toMatchObject({
+-+      versionId: 'cv-override',
+-+      payload: expect.objectContaining({
+-+        reason: 'Accepted risk for unresolved reconciliation decisions.',
+-+      }),
+-+    });
+-+  });
+-+
+-+  it('does not record override audit event when unresolved blocking count is zero', async () => {
+-+    vi.mocked(recordContentEvent).mockClear();
+-+    const details = minimalImportDetails();
+-+    const row = await attachReviewManifest(
+-+      {
+-+        id: 'imp-no-override',
+-+        status: 'PARSED',
+-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+-+        createdAt: new Date(),
+-+        versions: [],
+-+      },
+-+      details,
+-+      'imp-no-override',
+-+    );
+-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+-+    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
+-+      id: 'cv-no-override',
+-+      status: 'DRAFT',
+-+      draftSlot: 'main',
+-+      importId: 'imp-no-override',
+-+      payload: {},
+-+      label: null,
+-+      changeSummary: null,
+-+      createdBy: null,
+-+      createdAt: new Date(),
+-+      updatedAt: new Date(),
+-+      publishedAt: null,
+-+      publishSequence: null,
+-+    } as never);
+-+
+-+    await mergeImportCandidateToWorkingDraft({
+-+      importId: 'imp-no-override',
+-+      action: 'create',
+-+      acknowledgeUnresolvedReview: true,
+-+      unresolvedReviewReason: 'Should not be used when nothing is unresolved.',
+-+    });
+-+
+-+    const overrideEvents = vi
+-+      .mocked(recordContentEvent)
+-+      .mock.calls.filter(
+-+        (call) =>
+-+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
+-+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+-+      );
+-+    expect(overrideEvents).toHaveLength(0);
+-+  });
+- });
+diff --git a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+index 49ca33c..a5e4137 100644
 --- a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
 +++ b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
-@@ -154,6 +154,29 @@ function decisionControls(
-   );
- }
- 
-+function approvalBadgeStatus(
-+  draftApproval: LocalApproval | undefined,
-+  serverApproval: LocalApproval | undefined,
-+): 'pending' | 'unsaved' | 'saved' {
-+  if (draftApproval) {
-+    return 'unsaved';
-+  }
-+  if (serverApproval) {
-+    return 'saved';
-+  }
-+  return 'pending';
-+}
-+
-+function ApprovalStatusBadge({ status }: { status: 'pending' | 'unsaved' | 'saved' }) {
-+  if (status === 'saved') {
-+    return <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>;
-+  }
-+  if (status === 'unsaved') {
-+    return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">unsaved</span>;
-+  }
-+  return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>;
-+}
-+
- export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }: Props) {
-   const [draftApprovals, setDraftApprovals] = useState<LocalApproval[]>([]);
-   const [saving, setSaving] = useState(false);
-@@ -308,23 +331,22 @@ export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }:
-           <h3 className="text-sm font-medium text-foreground">{sectionLabel(section)}</h3>
-           <div className="space-y-3">
-             {decisions.map((decision) => {
-+              const serverApproval = serverApprovals.find((a) => a.decisionId === decision.decisionId);
-+              const draftApproval = draftApprovals.find((a) => a.decisionId === decision.decisionId);
-               const current = effectiveApprovals.get(decision.decisionId);
--              const isCluster = Boolean(decision.relatedExistingIds && decision.relatedExistingIds.length > 0);
--              const clusterMembers = isCluster
--                ? [decision.existingId!, ...(decision.relatedExistingIds ?? [])]
--                : [];
--              const resolved = Boolean(current);
-+              const clusterMemberIds = [decision.existingId, ...(decision.relatedExistingIds ?? [])].filter(
-+                (id): id is string => Boolean(id),
-+              );
-+              const isCluster = clusterMemberIds.length >= 2;
-+              const clusterMembers = isCluster ? clusterMemberIds : [];
-+              const approvalStatus = approvalBadgeStatus(draftApproval, serverApproval as LocalApproval | undefined);
- 
-               return (
-                 <div key={decision.decisionId} className="rounded border border-primary/15 p-3 text-xs space-y-2">
-                   <div className="flex flex-wrap items-center gap-2">
-                     <span className="font-medium text-foreground">{decision.action}</span>
-                     <span className="text-muted">confidence: {decision.confidence}</span>
--                    {resolved ? (
--                      <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>
--                    ) : (
--                      <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>
--                    )}
-+                    <ApprovalStatusBadge status={approvalStatus} />
-                   </div>
-                   <p className="text-foreground">{decision.reason}</p>
-                   {decision.existingId ? (
-diff --git a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
-index dbb13af..3dbecca 100644
---- a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
-+++ b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
-@@ -38,7 +38,8 @@ function mergeErrorResponse(e: ImportMergeError): NextResponse {
-     e.code === 'REVIEW_BLOCKED' ||
-     e.code === 'REVIEW_MANIFEST_MISSING' ||
-     e.code === 'REVIEW_MANIFEST_STALE' ||
--    e.code === 'REVIEW_APPROVALS_STALE'
-+    e.code === 'REVIEW_APPROVALS_STALE' ||
-+    e.code === 'REVIEW_APPROVALS_INVALID'
-   ) {
-     status = 422;
-   }
-diff --git a/src/server/imports/importCandidateReview/reconcile.ts b/src/server/imports/importCandidateReview/reconcile.ts
-index 50c12d9..a714662 100644
---- a/src/server/imports/importCandidateReview/reconcile.ts
-+++ b/src/server/imports/importCandidateReview/reconcile.ts
-@@ -48,15 +48,25 @@ export type LoadedImportReviewState = {
- export function loadImportReviewStateFromRow(row: {
-   reviewManifest: unknown;
-   reviewApprovals: unknown;
--  candidatePayload: unknown;
- }): LoadedImportReviewState | null {
-   const manifestEnvelope = parseStoredReviewManifest(row.reviewManifest);
-   if (!manifestEnvelope) {
-     return null;
-   }
--  const approvalsEnvelope = row.reviewApprovals
--    ? parseStoredReviewApprovals(row.reviewApprovals)
--    : null;
-+  const approvalsEnvelope =
-+    row.reviewApprovals === null || row.reviewApprovals === undefined
-+      ? null
-+      : parseStoredReviewApprovals(row.reviewApprovals);
-+  if (
-+    row.reviewApprovals !== null &&
-+    row.reviewApprovals !== undefined &&
-+    approvalsEnvelope === null
-+  ) {
-+    throw new ImportReviewReconcileError(
-+      'REVIEW_APPROVALS_INVALID',
-+      'Stored review approvals are malformed.',
-+    );
-+  }
-   const approvals = approvalsEnvelope?.approvals ?? [];
-   let manifest = manifestEnvelope.manifest as CandidateReviewManifest;
-   if (approvals.length > 0) {
-diff --git a/src/server/imports/importCandidateReview/revision.ts b/src/server/imports/importCandidateReview/revision.ts
-index 0d19e82..15a741e 100644
---- a/src/server/imports/importCandidateReview/revision.ts
-+++ b/src/server/imports/importCandidateReview/revision.ts
-@@ -7,7 +7,10 @@ export function computeImportReviewManifestRevision(input: {
-   sourceTextHash: string;
-   decisionIds: readonly string[];
- }): string {
--  const payload = `${input.sourceTextHash}\n${[...input.decisionIds].sort().join('\n')}`;
-+  const payload = JSON.stringify({
-+    sourceTextHash: input.sourceTextHash,
-+    decisionIds: [...input.decisionIds].sort(),
-+  });
-   return createHash('sha256').update(payload).digest('hex').slice(0, 32);
- }
- 
-diff --git a/src/server/imports/importCandidateReview/service.ts b/src/server/imports/importCandidateReview/service.ts
-index 74008de..3b449d4 100644
---- a/src/server/imports/importCandidateReview/service.ts
-+++ b/src/server/imports/importCandidateReview/service.ts
-@@ -1,5 +1,6 @@
- import 'server-only';
- 
-+import type { ImportStatus } from '@prisma/client';
- import { Prisma } from '@prisma/client';
- 
- import { recordContentEvent } from '@/server/content/contentEvents';
-@@ -28,6 +29,21 @@ import {
- } from '@/server/imports/importCandidateReview/storageSchema';
- import { ImportDomainError } from '@/server/imports/types';
- 
-+const REVIEW_APPROVAL_ALLOWED_STATUSES = new Set<ImportStatus>(['PARSED', 'NEEDS_REVIEW']);
-+
-+export function importStatusAcceptsReviewApprovalUpdates(status: ImportStatus): boolean {
-+  return REVIEW_APPROVAL_ALLOWED_STATUSES.has(status);
-+}
-+
-+function assertImportStatusAcceptsReviewApprovalUpdates(status: ImportStatus): void {
-+  if (!importStatusAcceptsReviewApprovalUpdates(status)) {
-+    throw new ImportReviewApprovalPersistError(
-+      'IMPORT_FINALIZED',
-+      `Import status "${status}" does not accept review approval updates.`,
-+    );
-+  }
-+}
-+
- export class ImportReviewApprovalPersistError extends Error {
-   constructor(
-     readonly code:
-@@ -137,14 +153,17 @@ export async function saveImportReviewApprovals(input: {
-   if (!row) {
-     throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
-   }
--  if (row.status === 'REJECTED' || row.status === 'FAILED') {
--    throw new ImportReviewApprovalPersistError(
--      'IMPORT_FINALIZED',
--      `Import status "${row.status}" does not accept review approval updates.`,
--    );
--  }
-+  assertImportStatusAcceptsReviewApprovalUpdates(row.status);
- 
--  const loaded = loadImportReviewStateFromRow(row);
-+  let loaded: ReturnType<typeof loadImportReviewStateFromRow>;
-+  try {
-+    loaded = loadImportReviewStateFromRow(row);
-+  } catch (e) {
-+    if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
-+      throw new ImportReviewApprovalPersistError('REVIEW_APPROVALS_INVALID', e.message);
-+    }
-+    throw e;
-+  }
-   if (!loaded) {
-     throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
-   }
-@@ -175,6 +194,7 @@ export async function saveImportReviewApprovals(input: {
-     if (!current) {
-       throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
-     }
-+    assertImportStatusAcceptsReviewApprovalUpdates(current.status);
-     const currentLoaded = loadImportReviewStateFromRow(current);
-     if (!currentLoaded) {
-       throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
-diff --git a/src/server/imports/importCandidateReview/storageSchema.ts b/src/server/imports/importCandidateReview/storageSchema.ts
-index 6d2052f..10c07f0 100644
---- a/src/server/imports/importCandidateReview/storageSchema.ts
-+++ b/src/server/imports/importCandidateReview/storageSchema.ts
-@@ -60,23 +60,38 @@ const advisorySectionAccountingSchema = z.object({
-   affectedRecordCount: z.number().int().nonnegative(),
- });
- 
--const candidateReviewManifestSchema = z.object({
--  generatedAt: z.string(),
--  importId: z.string().nullable().optional(),
--  importSource: z.string(),
--  baseline: reviewBaselineRefSchema,
--  decisions: z.array(reviewDecisionSchema),
--  analysisAccounting: z.object({
--    publications: reconciledSectionAccountingSchema,
--    awards: reconciledSectionAccountingSchema,
--  }),
--  accounting: z.object({
--    publications: reconciledSectionAccountingSchema,
--    awards: reconciledSectionAccountingSchema,
--    patents: advisorySectionAccountingSchema,
--    research: advisorySectionAccountingSchema,
--  }),
--});
-+const candidateReviewManifestSchema = z
-+  .object({
-+    generatedAt: z.string(),
-+    importId: z.string().nullable().optional(),
-+    importSource: z.string(),
-+    baseline: reviewBaselineRefSchema,
-+    decisions: z.array(reviewDecisionSchema),
-+    analysisAccounting: z.object({
-+      publications: reconciledSectionAccountingSchema,
-+      awards: reconciledSectionAccountingSchema,
-+    }),
-+    accounting: z.object({
-+      publications: reconciledSectionAccountingSchema,
-+      awards: reconciledSectionAccountingSchema,
-+      patents: advisorySectionAccountingSchema,
-+      research: advisorySectionAccountingSchema,
-+    }),
-+  })
-+  .superRefine((value, ctx) => {
-+    const seen = new Set<string>();
-+    value.decisions.forEach((d, idx) => {
-+      if (seen.has(d.decisionId)) {
-+        ctx.addIssue({
-+          code: z.ZodIssueCode.custom,
-+          path: ['decisions', idx, 'decisionId'],
-+          message: 'decisionId must be unique within a manifest.',
-+        });
-+        return;
-+      }
-+      seen.add(d.decisionId);
-+    });
-+  });
- 
- export const storedReviewManifestEnvelopeSchema = z.object({
-   storageVersion: z.literal(IMPORT_REVIEW_STORAGE_VERSION),
-diff --git a/src/server/imports/mergeImportToDraft.ts b/src/server/imports/mergeImportToDraft.ts
-index c79f927..d77ae32 100644
---- a/src/server/imports/mergeImportToDraft.ts
-+++ b/src/server/imports/mergeImportToDraft.ts
-@@ -42,7 +42,8 @@ export class ImportMergeError extends Error {
-       | 'REVIEW_BLOCKED'
-       | 'REVIEW_MANIFEST_MISSING'
-       | 'REVIEW_MANIFEST_STALE'
--      | 'REVIEW_APPROVALS_STALE',
-+      | 'REVIEW_APPROVALS_STALE'
-+      | 'REVIEW_APPROVALS_INVALID',
-     message: string,
-   ) {
-     super(message);
-@@ -71,6 +72,50 @@ export type MergeImportCandidateResult = {
-   alreadyMerged: boolean;
- };
- 
-+async function recordSuccessfulMergeEvents(input: {
-+  versionId: string;
-+  importId: string;
-+  action: 'create' | 'replace';
-+  draftEventType: 'WORKING_DRAFT_CREATED' | 'WORKING_DRAFT_UPDATED';
-+  draftEventPayload: Prisma.InputJsonValue;
-+  reconciledAccounting: Prisma.InputJsonValue | null;
-+  unresolvedBlockingCount: number;
-+  acknowledgedUnresolvedReview: boolean;
-+  normalizedUnresolvedReviewReason: string | null;
-+}): Promise<void> {
-+  await recordContentEvent({
-+    eventType: input.draftEventType,
-+    versionId: input.versionId,
-+    payload: input.draftEventPayload,
-+  });
-+  await recordContentEvent({
-+    eventType: 'SYSTEM_NOTE',
-+    versionId: input.versionId,
-+    payload: {
-+      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
-+      importId: input.importId,
-+      action: input.action,
-+      reconciledAccounting: input.reconciledAccounting,
-+      unresolvedBlockingCount: input.unresolvedBlockingCount,
-+      acknowledgedUnresolvedReview: input.acknowledgedUnresolvedReview,
-+      unresolvedReviewReason: input.normalizedUnresolvedReviewReason,
-+    },
-+  });
-+  if (input.acknowledgedUnresolvedReview) {
-+    await recordContentEvent({
-+      eventType: 'SYSTEM_NOTE',
-+      versionId: input.versionId,
-+      payload: {
-+        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
-+        importId: input.importId,
-+        versionId: input.versionId,
-+        unresolvedBlockingCount: input.unresolvedBlockingCount,
-+        reason: input.normalizedUnresolvedReviewReason,
-+      },
-+    });
-+  }
-+}
-+
- /**
-  * Creates a working draft from the import candidate, or replaces the existing draft payload.
-  * Never touches published rows. Sets `ContentVersion.importId` and marks the import `MERGED`.
-@@ -115,14 +160,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
-   const baselineData = basePayload.data;
- 
-   const manifestEnvelope = await ensureImportReviewManifest(input.importId);
-+  // Reload after ensureImportReviewManifest ÔÇö it may have lazily generated and persisted a manifest.
-   const reviewRow = await getContentImportDetail(input.importId);
--  const loadedReview = reviewRow
--    ? loadImportReviewStateFromRow({
-+  let loadedReview: ReturnType<typeof loadImportReviewStateFromRow> = null;
-+  if (reviewRow) {
-+    try {
-+      loadedReview = loadImportReviewStateFromRow({
-         reviewManifest: reviewRow.reviewManifest,
-         reviewApprovals: reviewRow.reviewApprovals,
--        candidatePayload: reviewRow.candidatePayload,
--      })
--    : null;
-+      });
-+    } catch (e) {
-+      if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
-+        throw new ImportMergeError('REVIEW_APPROVALS_INVALID', e.message);
-+      }
-+      throw e;
-+    }
-+  }
-   if (!loadedReview) {
-     throw new ImportMergeError('REVIEW_MANIFEST_MISSING', 'Import has no reconciliation review manifest.');
-   }
-@@ -166,29 +219,19 @@ export async function mergeImportCandidateToWorkingDraft(input: {
-     throw e;
-   }
- 
--  if (
--    input.acknowledgeUnresolvedReview &&
--    unresolvedBlockingCount > 0 &&
--    !input.unresolvedReviewReason?.trim()
--  ) {
-+  const acknowledgedUnresolvedReview =
-+    Boolean(input.acknowledgeUnresolvedReview) && unresolvedBlockingCount > 0;
-+  const normalizedUnresolvedReviewReason = acknowledgedUnresolvedReview
-+    ? (input.unresolvedReviewReason?.trim() ?? '')
-+    : '';
-+
-+  if (acknowledgedUnresolvedReview && normalizedUnresolvedReviewReason.length < 8) {
-     throw new ImportMergeError(
-       'MERGE_ACK_REQUIRED',
--      'Unresolved reconciliation override requires unresolvedReviewReason.',
-+      'Unresolved reconciliation override requires unresolvedReviewReason of at least 8 characters.',
+@@ -276,6 +276,19 @@ export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }:
      );
    }
  
--  if (input.acknowledgeUnresolvedReview && unresolvedBlockingCount > 0) {
--    await recordContentEvent({
--      eventType: 'SYSTEM_NOTE',
--      payload: {
--        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
--        importId: input.importId,
--        unresolvedBlockingCount,
--        reason: input.unresolvedReviewReason?.trim() ?? null,
--      },
--    });
--  }
--
-   const provenance: ImportReviewProvenance = {
-     importId: importRow.id,
-     originalFileName: importRow.uploadedFile.originalName,
-@@ -244,29 +287,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
-         createdBy: null,
-       },
-     });
--    await recordContentEvent({
--      eventType: 'WORKING_DRAFT_CREATED',
-+    await recordSuccessfulMergeEvents({
-       versionId: row.id,
--      payload: {
-+      importId: input.importId,
-+      action: 'create',
-+      draftEventType: 'WORKING_DRAFT_CREATED',
-+      draftEventPayload: {
-         importId: input.importId,
-         source: 'import_candidate',
-         reconciledAccounting,
-         unresolvedBlockingCount,
--        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
--      },
--    });
--    await recordContentEvent({
--      eventType: 'SYSTEM_NOTE',
--      versionId: row.id,
--      payload: {
--        kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
--        importId: input.importId,
--        action: 'create',
--        reconciledAccounting,
--        unresolvedBlockingCount,
--        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
--        unresolvedReviewReason: input.unresolvedReviewReason ?? null,
-+        acknowledgedUnresolvedReview,
-       },
-+      reconciledAccounting,
-+      unresolvedBlockingCount,
-+      acknowledgedUnresolvedReview,
-+      normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
-     });
-     await updateImportStatus(input.importId, 'MERGED');
-     return { version: row, alreadyMerged: false };
-@@ -283,29 +319,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
-       changeSummary: input.changeSummary ?? working.changeSummary,
-     },
++  if (reconcile.loadError) {
++    return (
++      <div className="card p-4 space-y-3">
++        <h2 className="text-lg font-semibold text-foreground">Candidate reconciliation review</h2>
++        <div className="rounded border border-error/40 bg-error/10 px-3 py-2 text-sm text-foreground space-y-1">
++          <p className="font-medium">Stored reconciliation data is invalid.</p>
++          <p>Merge is blocked. Reprocess the import or repair the stored review data.</p>
++          <p className="text-xs text-muted">{reconcile.loadError.message}</p>
++        </div>
++      </div>
++    );
++  }
++
+   const pub = reconcile.accounting as {
+     publications?: { candidateTotal?: number; baselineTotal?: number };
+     awards?: { candidateTotal?: number; baselineTotal?: number };
+diff --git a/src/app/admin/imports/importDetailTypes.ts b/src/app/admin/imports/importDetailTypes.ts
+index 8e72516..21430d6 100644
+--- a/src/app/admin/imports/importDetailTypes.ts
++++ b/src/app/admin/imports/importDetailTypes.ts
+@@ -72,6 +72,10 @@ export type ImportCandidateReconcileReviewModel = {
+   unresolvedBlockingCount: number;
+   mergeReviewBlocked: boolean;
+   advisoryOnly: boolean;
++  loadError?: {
++    code: 'REVIEW_MANIFEST_INVALID' | 'REVIEW_APPROVALS_INVALID' | 'REVIEW_APPROVALS_STALE';
++    message: string;
++  } | null;
+ };
+ 
+ export type ImportDetailModel = {
+diff --git a/src/server/imports/importCandidateReview/service.ts b/src/server/imports/importCandidateReview/service.ts
+index 3b449d4..2a7454e 100644
+--- a/src/server/imports/importCandidateReview/service.ts
++++ b/src/server/imports/importCandidateReview/service.ts
+@@ -190,12 +190,28 @@ export async function saveImportReviewApprovals(input: {
    });
--  await recordContentEvent({
--    eventType: 'WORKING_DRAFT_UPDATED',
-+  await recordSuccessfulMergeEvents({
-     versionId: row.id,
--    payload: {
-+    importId: input.importId,
-+    action: 'replace',
-+    draftEventType: 'WORKING_DRAFT_UPDATED',
-+    draftEventPayload: {
-       importId: input.importId,
-       source: 'import_candidate_replace',
-       reconciledAccounting,
-       unresolvedBlockingCount,
--      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
--    },
--  });
--  await recordContentEvent({
--    eventType: 'SYSTEM_NOTE',
--    versionId: row.id,
--    payload: {
--      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
--      importId: input.importId,
--      action: 'replace',
--      reconciledAccounting,
--      unresolvedBlockingCount,
--      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
--      unresolvedReviewReason: input.unresolvedReviewReason ?? null,
-+      acknowledgedUnresolvedReview,
-     },
-+    reconciledAccounting,
-+    unresolvedBlockingCount,
-+    acknowledgedUnresolvedReview,
-+    normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
-   });
-   await updateImportStatus(input.importId, 'MERGED');
-   return { version: row, alreadyMerged: false };
+ 
+   await prisma.$transaction(async (tx) => {
++    await tx.$queryRaw`
++      SELECT "id"
++      FROM "ContentImport"
++      WHERE "id" = ${input.importId}
++      FOR UPDATE
++    `;
++
+     const current = await tx.contentImport.findUnique({ where: { id: input.importId } });
+     if (!current) {
+       throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
+     }
+     assertImportStatusAcceptsReviewApprovalUpdates(current.status);
+-    const currentLoaded = loadImportReviewStateFromRow(current);
++
++    let currentLoaded: ReturnType<typeof loadImportReviewStateFromRow>;
++    try {
++      currentLoaded = loadImportReviewStateFromRow(current);
++    } catch (e) {
++      if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
++        throw new ImportReviewApprovalPersistError('REVIEW_APPROVALS_INVALID', e.message);
++      }
++      throw e;
++    }
+     if (!currentLoaded) {
+       throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
+     }
+diff --git a/src/server/imports/importCandidateReview/state.ts b/src/server/imports/importCandidateReview/state.ts
+index 3ccaefa..ecb318c 100644
+--- a/src/server/imports/importCandidateReview/state.ts
++++ b/src/server/imports/importCandidateReview/state.ts
+@@ -8,6 +8,16 @@ import type {
+ } from '@/server/imports/candidateReviewManifest';
+ import type { StoredReviewApprovalsEnvelope, StoredReviewManifestEnvelope } from '@/server/imports/importCandidateReview/storageSchema';
+ 
++export type ImportCandidateReconcileLoadErrorCode =
++  | 'REVIEW_MANIFEST_INVALID'
++  | 'REVIEW_APPROVALS_INVALID'
++  | 'REVIEW_APPROVALS_STALE';
++
++export type ImportCandidateReconcileLoadErrorDto = {
++  code: ImportCandidateReconcileLoadErrorCode;
++  message: string;
++};
++
+ export type ImportCandidateReviewStateDto = {
+   hasManifest: boolean;
+   manifestRevision: string | null;
+@@ -23,6 +33,7 @@ export type ImportCandidateReviewStateDto = {
+   unresolvedBlockingCount: number;
+   mergeReviewBlocked: boolean;
+   advisoryOnly: boolean;
++  loadError: ImportCandidateReconcileLoadErrorDto | null;
+ };
+ 
+ export function buildImportCandidateReviewStateDto(input: {
+@@ -54,6 +65,31 @@ export function buildImportCandidateReviewStateDto(input: {
+         (manifest.accounting.patents.unresolvedAdvisoryDecisions > 0 ||
+           manifest.accounting.research.unresolvedAdvisoryDecisions > 0),
+     ),
++    loadError: null,
++  };
++}
++
++export function buildImportCandidateReviewCorruptedDto(input: {
++  code: ImportCandidateReconcileLoadErrorCode;
++  message: string;
++  hasManifest: boolean;
++}): ImportCandidateReviewStateDto {
++  return {
++    hasManifest: input.hasManifest,
++    manifestRevision: null,
++    sourceTextHash: null,
++    baseline: null,
++    generatedAt: null,
++    importSource: null,
++    decisions: [],
++    accounting: null,
++    analysisAccounting: null,
++    approvals: [],
++    approvalsUpdatedAt: null,
++    unresolvedBlockingCount: 1,
++    mergeReviewBlocked: true,
++    advisoryOnly: false,
++    loadError: { code: input.code, message: input.message },
+   };
+ }
+ 
 diff --git a/src/server/imports/serialize.ts b/src/server/imports/serialize.ts
-index 170d65f..bc022ed 100644
+index bc022ed..b434bdb 100644
 --- a/src/server/imports/serialize.ts
 +++ b/src/server/imports/serialize.ts
-@@ -144,7 +144,6 @@ export function buildImportCandidateReconcileReview(
-   const loaded = loadImportReviewStateFromRow({
-     reviewManifest: row.reviewManifest,
-     reviewApprovals: row.reviewApprovals,
--    candidatePayload: null,
-   });
-   if (!loaded) {
+@@ -4,8 +4,16 @@ import type { ContentImport, UploadedFile } from '@prisma/client';
+ 
+ import { getDetailsFromCandidatePayload, parseImportCandidatePayload } from '@/server/imports/candidatePayload/schema';
+ import { countUnresolvedBlockingDecisions } from '@/server/imports/importCandidateReview/gate';
+-import { loadImportReviewStateFromRow } from '@/server/imports/importCandidateReview/reconcile';
+-import { buildImportCandidateReviewStateDto } from '@/server/imports/importCandidateReview/state';
++import {
++  ImportReviewReconcileError,
++  loadImportReviewStateFromRow,
++  verifyReviewApprovalsRevision,
++} from '@/server/imports/importCandidateReview/reconcile';
++import {
++  buildImportCandidateReviewCorruptedDto,
++  buildImportCandidateReviewStateDto,
++  type ImportCandidateReconcileLoadErrorCode,
++} from '@/server/imports/importCandidateReview/state';
+ import {
+   importWarningItemSchema,
+   type ImportCandidateReconcileReviewDto,
+@@ -138,23 +146,63 @@ export function buildImportCandidateSummary(payload: unknown): ImportCandidateSu
+   };
+ }
+ 
++const RECONCILE_ADMIN_LOAD_ERROR_CODES = new Set<ImportReviewReconcileError['code']>([
++  'REVIEW_MANIFEST_INVALID',
++  'REVIEW_APPROVALS_INVALID',
++  'REVIEW_APPROVALS_STALE',
++]);
++
++function adminFacingReconcileLoadMessage(code: ImportCandidateReconcileLoadErrorCode): string {
++  switch (code) {
++    case 'REVIEW_MANIFEST_INVALID':
++      return 'Stored reconciliation manifest is invalid.';
++    case 'REVIEW_APPROVALS_INVALID':
++      return 'Stored reconciliation approvals are invalid.';
++    case 'REVIEW_APPROVALS_STALE':
++      return 'Stored reconciliation approvals do not match the current manifest revision.';
++  }
++}
++
+ export function buildImportCandidateReconcileReview(
+   row: Pick<ContentImport, 'reviewManifest' | 'reviewApprovals'>,
+ ): ImportCandidateReconcileReviewDto | null {
+-  const loaded = loadImportReviewStateFromRow({
+-    reviewManifest: row.reviewManifest,
+-    reviewApprovals: row.reviewApprovals,
+-  });
+-  if (!loaded) {
++  const hasStoredManifest = row.reviewManifest !== null && row.reviewManifest !== undefined;
++  if (!hasStoredManifest) {
      return null;
+   }
+-  return buildImportCandidateReviewStateDto({
+-    manifestEnvelope: loaded.manifestEnvelope,
+-    manifest: loaded.manifest,
+-    approvalsEnvelope: loaded.approvalsEnvelope,
+-    approvals: loaded.approvals,
+-    unresolvedBlockingCount: countUnresolvedBlockingDecisions(loaded.manifest),
+-  });
++
++  try {
++    const loaded = loadImportReviewStateFromRow({
++      reviewManifest: row.reviewManifest,
++      reviewApprovals: row.reviewApprovals,
++    });
++    if (!loaded) {
++      return buildImportCandidateReviewCorruptedDto({
++        code: 'REVIEW_MANIFEST_INVALID',
++        message: adminFacingReconcileLoadMessage('REVIEW_MANIFEST_INVALID'),
++        hasManifest: true,
++      });
++    }
++    if (loaded.approvalsEnvelope) {
++      verifyReviewApprovalsRevision(loaded.manifestEnvelope, loaded.approvalsEnvelope);
++    }
++    return buildImportCandidateReviewStateDto({
++      manifestEnvelope: loaded.manifestEnvelope,
++      manifest: loaded.manifest,
++      approvalsEnvelope: loaded.approvalsEnvelope,
++      approvals: loaded.approvals,
++      unresolvedBlockingCount: countUnresolvedBlockingDecisions(loaded.manifest),
++    });
++  } catch (e) {
++    if (e instanceof ImportReviewReconcileError && RECONCILE_ADMIN_LOAD_ERROR_CODES.has(e.code)) {
++      return buildImportCandidateReviewCorruptedDto({
++        code: e.code as ImportCandidateReconcileLoadErrorCode,
++        message: adminFacingReconcileLoadMessage(e.code as ImportCandidateReconcileLoadErrorCode),
++        hasManifest: true,
++      });
++    }
++    throw e;
++  }
+ }
+ 
+ export function toImportDetail(row: ImportWithFileAndVersions): ImportDetailDto {
+diff --git a/src/server/imports/types.ts b/src/server/imports/types.ts
+index 79783ea..0f093f8 100644
+--- a/src/server/imports/types.ts
++++ b/src/server/imports/types.ts
+@@ -132,6 +132,10 @@ export type ImportCandidateReconcileReviewDto = {
+   unresolvedBlockingCount: number;
+   mergeReviewBlocked: boolean;
+   advisoryOnly: boolean;
++  loadError: {
++    code: 'REVIEW_MANIFEST_INVALID' | 'REVIEW_APPROVALS_INVALID' | 'REVIEW_APPROVALS_STALE';
++    message: string;
++  } | null;
+ };
+ 
+ export type ImportDetailDto = ImportSummaryDto & {
 diff --git a/src/tests/imports/importCandidateReconcilePanel.test.tsx b/src/tests/imports/importCandidateReconcilePanel.test.tsx
-index 9cbd070..785a795 100644
+index 785a795..0fd3da7 100644
 --- a/src/tests/imports/importCandidateReconcilePanel.test.tsx
 +++ b/src/tests/imports/importCandidateReconcilePanel.test.tsx
-@@ -1,6 +1,6 @@
- /** @vitest-environment happy-dom */
+@@ -58,6 +58,7 @@ const reconcile: ImportCandidateReconcileReviewModel = {
+   unresolvedBlockingCount: 3,
+   mergeReviewBlocked: true,
+   advisoryOnly: false,
++  loadError: null,
+ };
  
--import { fireEvent, render, screen } from '@testing-library/react';
-+import { fireEvent, render, screen, within } from '@testing-library/react';
- import { describe, expect, it, vi } from 'vitest';
- 
- import { ImportCandidateReconcilePanel } from '@/app/admin/imports/ImportCandidateReconcilePanel';
-@@ -82,6 +82,33 @@ describe('ImportCandidateReconcilePanel', () => {
-     expect(screen.getByRole('button', { name: /Remove entire cluster/i })).toBeTruthy();
+ describe('ImportCandidateReconcilePanel', () => {
+@@ -109,6 +110,34 @@ describe('ImportCandidateReconcilePanel', () => {
+     expect(artifactCard?.textContent).toContain('saved');
    });
  
-+  it('shows unsaved badge for local draft approval before save', () => {
-+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={vi.fn()} />);
-+    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div')!;
-+    expect(artifactCard.textContent).toContain('pending');
-+    fireEvent.click(within(artifactCard).getByRole('button', { name: /Approve removal/i }));
-+    expect(artifactCard.textContent).toContain('unsaved');
-+    expect(within(artifactCard).getByText('unsaved')).toBeTruthy();
-+  });
-+
-+  it('shows saved badge for server-persisted approval', () => {
-+    const withSavedApproval: ImportCandidateReconcileReviewModel = {
-+      ...reconcile,
-+      approvals: [
-+        {
-+          decisionId: 'awards:artifact-1::remove-artifact',
-+          approvedAction: 'approve-removal',
-+        },
-+      ],
-+      unresolvedBlockingCount: 2,
++  it('renders blocking error card when stored reconciliation data is corrupted', () => {
++    const corrupted: ImportCandidateReconcileReviewModel = {
++      hasManifest: true,
++      manifestRevision: null,
++      sourceTextHash: null,
++      baseline: null,
++      generatedAt: null,
++      importSource: null,
++      decisions: [],
++      accounting: null,
++      analysisAccounting: null,
++      approvals: [],
++      approvalsUpdatedAt: null,
++      unresolvedBlockingCount: 1,
++      mergeReviewBlocked: true,
++      advisoryOnly: false,
++      loadError: {
++        code: 'REVIEW_APPROVALS_INVALID',
++        message: 'Stored reconciliation approvals are invalid.',
++      },
 +    };
-+    render(
-+      <ImportCandidateReconcilePanel importId="imp-1" reconcile={withSavedApproval} onSaved={vi.fn()} />,
-+    );
-+    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div');
-+    expect(artifactCard?.textContent).toContain('saved');
++    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={corrupted} onSaved={vi.fn()} />);
++    expect(screen.getByText(/Stored reconciliation data is invalid/i)).toBeTruthy();
++    expect(screen.getByText(/Merge is blocked/i)).toBeTruthy();
++    expect(screen.queryByRole('button', { name: /Save reconciliation approvals/i })).toBeNull();
++    expect(screen.queryByRole('button', { name: /Approve removal/i })).toBeNull();
 +  });
 +
    it('submits approvals to API', async () => {
      const fetchMock = vi.fn().mockResolvedValue({
        ok: true,
 diff --git a/src/tests/imports/importCandidateReviewWorkflow.test.ts b/src/tests/imports/importCandidateReviewWorkflow.test.ts
-index 07ff401..9442da5 100644
+index 9442da5..7f9ae15 100644
 --- a/src/tests/imports/importCandidateReviewWorkflow.test.ts
 +++ b/src/tests/imports/importCandidateReviewWorkflow.test.ts
-@@ -39,13 +39,16 @@ import {
-   generateImportReviewManifest,
-   summarizeReviewManifestForAudit,
- } from '@/server/imports/importCandidateReview/generate';
-+import { loadImportReviewStateFromRow } from '@/server/imports/importCandidateReview/reconcile';
- import { computeImportReviewManifestRevision } from '@/server/imports/importCandidateReview/revision';
- import {
-   saveImportReviewApprovals,
-+  importStatusAcceptsReviewApprovalUpdates,
- } from '@/server/imports/importCandidateReview/service';
- import {
-   parseStoredReviewApprovals,
-   parseStoredReviewManifest,
-+  storedReviewManifestEnvelopeSchema,
-   toStoredApprovalsEnvelope,
- } from '@/server/imports/importCandidateReview/storageSchema';
- import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
-@@ -94,8 +97,9 @@ describe('import candidate review storage', () => {
-       candidate,
-     });
-     const decision = manifest.decisions.find((d) => d.action === 'manual-review');
-+    expect(decision).toBeDefined();
-     if (!decision) {
--      return;
-+      throw new Error('Expected at least one manual-review decision for this fixture.');
-     }
-     vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
-       id: IMPORT_ID,
-@@ -126,8 +130,9 @@ describe('import candidate review storage', () => {
-     const decision = manifest.decisions.find(
-       (d) => d.section === 'publications' && d.action === 'manual-review',
-     );
-+    expect(decision).toBeDefined();
-     if (!decision) {
--      return;
-+      throw new Error('Expected a publications manual-review decision for this fixture.');
-     }
-     const approvalsEnvelope = toStoredApprovalsEnvelope({
-       manifestRevision: envelope.manifestRevision,
-@@ -246,6 +251,133 @@ describe('import candidate review storage', () => {
-     expect(parseStoredReviewApprovals(approvals)?.manifestRevision).toBe(revisionA);
-   });
+@@ -55,6 +55,35 @@ import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
  
-+  it('rejects duplicate decisionId values in stored manifest envelope', async () => {
-+    const candidate = minimalImportDetails();
-+    const payload = envelopeFromDetails(candidate);
-+    const { envelope, manifest } = await generateImportReviewManifest({
-+      importId: IMPORT_ID,
-+      sourceFileName: 'cv.docx',
-+      sourceTextHash: payload.sourceTextHash,
-+      candidate,
-+    });
-+    expect(manifest.decisions.length).toBeGreaterThan(0);
-+    const duplicateDecision = { ...manifest.decisions[0]! };
-+    const malformed = {
-+      ...envelope,
-+      manifest: {
-+        ...manifest,
-+        decisions: [...manifest.decisions, duplicateDecision],
-+      },
+ const IMPORT_ID = 'imp-review-workflow';
+ 
++function mockApprovalSaveTransaction(input: {
++  importId: string;
++  row: Record<string, unknown>;
++  onLocked?: () => void;
++}) {
++  const callOrder: string[] = [];
++  const queryRaw = vi.fn(async () => {
++    callOrder.push('lock');
++    input.onLocked?.();
++    return [{ id: input.importId }];
++  });
++  const findUnique = vi.fn(async () => {
++    callOrder.push('read');
++    return input.row;
++  });
++  const update = vi.fn(async () => {
++    callOrder.push('update');
++    return {};
++  });
++  vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
++    const tx = {
++      $queryRaw: queryRaw,
++      contentImport: { findUnique, update },
 +    };
-+    expect(parseStoredReviewManifest(malformed)).toBeNull();
++    return fn(tx as never);
 +  });
++  return { callOrder, queryRaw, findUnique, update };
++}
 +
-+  it('accepts unique decisionId values in stored manifest envelope', async () => {
-+    const candidate = minimalImportDetails();
-+    const payload = envelopeFromDetails(candidate);
-+    const { envelope } = await generateImportReviewManifest({
+ function envelopeFromDetails(details = minimalImportDetails(), rawDocumentText = 'cv body text for hash') {
+   return buildImportCandidatePayload({
+     rawDocumentText,
+@@ -164,6 +193,7 @@ describe('import candidate review storage', () => {
+ 
+     vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
+       const tx = {
++        $queryRaw: vi.fn().mockResolvedValue([{ id: IMPORT_ID }]),
+         contentImport: {
+           findUnique: vi.fn().mockResolvedValue({
+             id: IMPORT_ID,
+@@ -326,20 +356,15 @@ describe('import candidate review storage', () => {
+       reviewApprovals: null,
+     } as never);
+ 
+-    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
+-      const tx = {
+-        contentImport: {
+-          findUnique: vi.fn().mockResolvedValue({
+-            id: IMPORT_ID,
+-            status: 'MERGED',
+-            candidatePayload: payload,
+-            reviewManifest: envelope,
+-            reviewApprovals: null,
+-          }),
+-          update: vi.fn(),
+-        },
+-      };
+-      return fn(tx as never);
++    const { callOrder, update } = mockApprovalSaveTransaction({
 +      importId: IMPORT_ID,
-+      sourceFileName: 'cv.docx',
-+      sourceTextHash: payload.sourceTextHash,
-+      candidate,
-+    });
-+    expect(storedReviewManifestEnvelopeSchema.safeParse(envelope).success).toBe(true);
-+  });
-+
-+  it('fails closed when stored approvals are malformed', async () => {
-+    const candidate = minimalImportDetails();
-+    const payload = envelopeFromDetails(candidate);
-+    const { envelope } = await generateImportReviewManifest({
-+      importId: IMPORT_ID,
-+      sourceFileName: 'cv.docx',
-+      sourceTextHash: payload.sourceTextHash,
-+      candidate,
-+    });
-+    expect(() =>
-+      loadImportReviewStateFromRow({
++      row: {
++        id: IMPORT_ID,
++        status: 'MERGED',
++        candidatePayload: payload,
 +        reviewManifest: envelope,
-+        reviewApprovals: { not: 'valid' },
-+      }),
-+    ).toThrowError(expect.objectContaining({ code: 'REVIEW_APPROVALS_INVALID' }));
++        reviewApprovals: null,
++      },
+     });
+ 
+     await expect(
+@@ -349,6 +374,128 @@ describe('import candidate review storage', () => {
+         approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+       }),
+     ).rejects.toMatchObject({ code: 'IMPORT_FINALIZED' });
++    expect(callOrder).toEqual(['lock', 'read']);
++    expect(update).not.toHaveBeenCalled();
 +  });
 +
-+  it('rejects approval save when import status flips to finalized inside transaction', async () => {
++  it('locks the import row before reading and updating approvals', async () => {
 +    const candidate = minimalImportDetails();
 +    const payload = envelopeFromDetails(candidate);
 +    const { envelope, manifest } = await generateImportReviewManifest({
@@ -638,6 +1338,79 @@ index 07ff401..9442da5 100644
 +      throw new Error('Expected a publications manual-review decision for this fixture.');
 +    }
 +
++    vi.mocked(prisma.contentImport.findUnique)
++      .mockResolvedValueOnce({
++        id: IMPORT_ID,
++        status: 'PARSED',
++        candidatePayload: payload,
++        reviewManifest: envelope,
++        reviewApprovals: null,
++      } as never)
++      .mockResolvedValueOnce({
++        id: IMPORT_ID,
++        status: 'PARSED',
++        candidatePayload: payload,
++        reviewManifest: envelope,
++        reviewApprovals: toStoredApprovalsEnvelope({
++          manifestRevision: envelope.manifestRevision,
++          approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
++        }),
++      } as never)
++      .mockResolvedValueOnce({
++        id: IMPORT_ID,
++        status: 'PARSED',
++        candidatePayload: payload,
++        reviewManifest: envelope,
++        reviewApprovals: toStoredApprovalsEnvelope({
++          manifestRevision: envelope.manifestRevision,
++          approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
++        }),
++      } as never);
++
++    const { callOrder, queryRaw, findUnique, update } = mockApprovalSaveTransaction({
++      importId: IMPORT_ID,
++      row: {
++        id: IMPORT_ID,
++        status: 'PARSED',
++        candidatePayload: payload,
++        reviewManifest: envelope,
++        reviewApprovals: null,
++      },
++    });
++
++    await saveImportReviewApprovals({
++      importId: IMPORT_ID,
++      manifestRevision: envelope.manifestRevision,
++      approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
++    });
++
++    expect(queryRaw).toHaveBeenCalledTimes(1);
++    expect(callOrder).toEqual(['lock', 'read', 'update']);
++    expect(findUnique).toHaveBeenCalledTimes(1);
++    expect(update).toHaveBeenCalledTimes(1);
++  });
++
++  it('rejects approval save when manifest revision changes after row lock', async () => {
++    const candidate = minimalImportDetails();
++    const payload = envelopeFromDetails(candidate);
++    const { envelope, manifest } = await generateImportReviewManifest({
++      importId: IMPORT_ID,
++      sourceFileName: 'cv.docx',
++      sourceTextHash: payload.sourceTextHash,
++      candidate,
++    });
++    const decision = manifest.decisions.find(
++      (d) => d.section === 'publications' && d.action === 'manual-review',
++    );
++    expect(decision).toBeDefined();
++    if (!decision) {
++      throw new Error('Expected a publications manual-review decision for this fixture.');
++    }
++    const staleEnvelope = {
++      ...envelope,
++      manifestRevision: 'deadbeefdeadbeefdeadbeefdeadbeef',
++    };
++
 +    vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
 +      id: IMPORT_ID,
 +      status: 'PARSED',
@@ -646,20 +1419,15 @@ index 07ff401..9442da5 100644
 +      reviewApprovals: null,
 +    } as never);
 +
-+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
-+      const tx = {
-+        contentImport: {
-+          findUnique: vi.fn().mockResolvedValue({
-+            id: IMPORT_ID,
-+            status: 'MERGED',
-+            candidatePayload: payload,
-+            reviewManifest: envelope,
-+            reviewApprovals: null,
-+          }),
-+          update: vi.fn(),
-+        },
-+      };
-+      return fn(tx as never);
++    const { callOrder, update } = mockApprovalSaveTransaction({
++      importId: IMPORT_ID,
++      row: {
++        id: IMPORT_ID,
++        status: 'PARSED',
++        candidatePayload: payload,
++        reviewManifest: staleEnvelope,
++        reviewApprovals: null,
++      },
 +    });
 +
 +    await expect(
@@ -668,270 +1436,146 @@ index 07ff401..9442da5 100644
 +        manifestRevision: envelope.manifestRevision,
 +        approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
 +      }),
-+    ).rejects.toMatchObject({ code: 'IMPORT_FINALIZED' });
-+  });
-+
-+  it('documents allowed import statuses for review approval updates', () => {
-+    expect(importStatusAcceptsReviewApprovalUpdates('PARSED')).toBe(true);
-+    expect(importStatusAcceptsReviewApprovalUpdates('NEEDS_REVIEW')).toBe(true);
-+    expect(importStatusAcceptsReviewApprovalUpdates('MERGED')).toBe(false);
-+    expect(importStatusAcceptsReviewApprovalUpdates('REJECTED')).toBe(false);
-+    expect(importStatusAcceptsReviewApprovalUpdates('FAILED')).toBe(false);
-+    expect(importStatusAcceptsReviewApprovalUpdates('UPLOADED')).toBe(false);
-+  });
-+
-+  it('uses unambiguous revision serialization for unusual decision ids', () => {
-+    const hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-+    const revisionA = computeImportReviewManifestRevision({
-+      sourceTextHash: hash,
-+      decisionIds: ['id\nb', 'id'],
-+    });
-+    const revisionB = computeImportReviewManifestRevision({
-+      sourceTextHash: hash,
-+      decisionIds: ['id', 'id\nb'],
-+    });
-+    const revisionC = computeImportReviewManifestRevision({
-+      sourceTextHash: hash,
-+      decisionIds: ['id', 'idb'],
-+    });
-+    expect(revisionA).toBe(revisionB);
-+    expect(revisionA).not.toBe(revisionC);
-+  });
-+
-   it('advisory patent decisions do not block merge accounting count', async () => {
-     const baseline = assertSiteContent(SITE_CONTENT_RAW);
-     const candidate = minimalImportDetails({
++    ).rejects.toMatchObject({ code: 'CONCURRENT_UPDATE' });
++    expect(callOrder).toEqual(['lock', 'read']);
++    expect(update).not.toHaveBeenCalled();
+   });
+ 
+   it('documents allowed import statuses for review approval updates', () => {
 diff --git a/src/tests/imports/importsDomain.test.ts b/src/tests/imports/importsDomain.test.ts
-index 5be36e8..30589a5 100644
+index 30589a5..08479c8 100644
 --- a/src/tests/imports/importsDomain.test.ts
 +++ b/src/tests/imports/importsDomain.test.ts
-@@ -129,6 +129,7 @@ describe('importsDomain', () => {
-       rawHtmlTruncated: false,
-     });
-     expect(detail.candidateReview).toBeNull();
-+    expect(detail.candidateReconcileReview).toBeNull();
-   });
+@@ -3,6 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  
-   it('toImportDetail has null candidateReview for malformed candidatePayload', () => {
-@@ -162,6 +163,7 @@ describe('importsDomain', () => {
-     const detail = toImportDetail(row);
-     expect(detail.candidateReview).toBeNull();
-     expect(detail.candidateSummary).toBeNull();
-+    expect(detail.candidateReconcileReview).toBeNull();
-   });
+ vi.mock('server-only', () => ({}));
  
-   it('toImportDetail includes candidateReview for envelope payloads', () => {
-@@ -215,6 +217,7 @@ describe('importsDomain', () => {
-     const patentEntry = detail.candidateReview!.countValidation.entries.find((e) => e.code === 'PATENT_COUNT_MISMATCH');
-     expect(patentEntry).toBeDefined();
-     expect(patentEntry!.severity).toBe('warning');
-+    expect(detail.candidateReconcileReview).toBeNull();
-   });
- });
++vi.mock('@/server/content/contentWorkflowCore', async () => {
++  const actual = await vi.importActual('@/server/content/contentWorkflowCore');
++  return {
++    ...(actual as Record<string, unknown>),
++    getWorkingDraft: vi.fn().mockResolvedValue(null),
++    getLatestPublishedVersion: vi.fn().mockResolvedValue(null),
++  };
++});
++
+ vi.mock('@/server/db/prisma', () => ({
+   prisma: {
+     uploadedFile: { findUnique: vi.fn(), create: vi.fn() },
+@@ -13,14 +22,18 @@ vi.mock('@/server/db/prisma', () => ({
  
-diff --git a/src/tests/imports/mergeImportToDraft.test.ts b/src/tests/imports/mergeImportToDraft.test.ts
-index e2285e2..a1babad 100644
---- a/src/tests/imports/mergeImportToDraft.test.ts
-+++ b/src/tests/imports/mergeImportToDraft.test.ts
-@@ -35,6 +35,7 @@ vi.mock('@/server/imports/importCandidateReview/service', () => ({
- 
- import { SITE_CONTENT_RAW } from '@/content/defaults';
- import { assertSiteContent, validateSiteContent } from '@/content/validators';
-+import { recordContentEvent } from '@/server/content/contentEvents';
- import { getWorkingDraft } from '@/server/content/contentWorkflowCore';
  import { prisma } from '@/server/db/prisma';
  import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
-@@ -62,6 +63,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
-     details: ReturnType<typeof minimalImportDetails>,
-     importId: string,
-     rawDocumentText = 'body',
-+    options?: { resolveBlocking?: boolean },
-   ) {
-     const envelope = buildImportCandidatePayload({
-       rawDocumentText,
-@@ -80,7 +82,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
-       .filter((d) => (d.action === 'manual-review' || d.action === 'remove-artifact') && d.section !== 'patents' && d.section !== 'research')
-       .map((d) => ({ decisionId: d.decisionId, approvedAction: 'skip' as const }));
-     const approvalsEnvelope =
--      blockingApprovals.length > 0
-+      options?.resolveBlocking !== false && blockingApprovals.length > 0
-         ? toStoredApprovalsEnvelope({
-             manifestRevision: reviewEnvelope.manifestRevision,
-             approvals: blockingApprovals,
-@@ -477,4 +479,176 @@ describe('mergeImportCandidateToWorkingDraft', () => {
-       expect(validated.data.patents.items).toHaveLength(5);
-     }
++import { generateImportReviewManifest } from '@/server/imports/importCandidateReview/generate';
++import * as reconcileModule from '@/server/imports/importCandidateReview/reconcile';
++import { toStoredApprovalsEnvelope } from '@/server/imports/importCandidateReview/storageSchema';
+ import { isTerminalImportStatus } from '@/server/imports/importStatus';
+ import {
+   createContentImportRecord,
+   saveImportCandidateAndWarnings,
+   updateImportStatus,
+ } from '@/server/imports/repository';
+-import { parseImportWarnings, toImportDetail, toImportSummary } from '@/server/imports/serialize';
++import { parseImportWarnings, toImportDetail, toImportSummary, buildImportCandidateReconcileReview } from '@/server/imports/serialize';
+ import { ImportDomainError } from '@/server/imports/types';
++import { minimalImportDetails as fixtureImportDetails } from '@/tests/fixtures/minimalImportDetails';
+ import type { DetectedSection } from '@/types/parser';
+ import { validateDetails } from '@/validators/detailsSchema';
+ 
+@@ -132,6 +145,96 @@ describe('importsDomain', () => {
+     expect(detail.candidateReconcileReview).toBeNull();
    });
-+
-+  it('rejects unresolved review override when reason is shorter than 8 characters', async () => {
-+    const details = minimalImportDetails();
-+    const row = await attachReviewManifest(
-+      {
-+        id: 'imp-short-reason',
-+        status: 'PARSED',
-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-+        createdAt: new Date(),
-+        versions: [],
-+      },
-+      details,
-+      'imp-short-reason',
-+      'body',
-+      { resolveBlocking: false },
-+    );
-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
-+
-+    await expect(
-+      mergeImportCandidateToWorkingDraft({
-+        importId: 'imp-short-reason',
-+        action: 'create',
-+        acknowledgeUnresolvedReview: true,
-+        unresolvedReviewReason: 'short',
-+      }),
-+    ).rejects.toMatchObject({ code: 'MERGE_ACK_REQUIRED' });
-+    expect(prisma.contentVersion.create).not.toHaveBeenCalled();
-+  });
-+
-+  it('does not record override audit event when merge fails after acknowledgement', async () => {
-+    vi.mocked(recordContentEvent).mockClear();
-+    const details = minimalImportDetails();
-+    const row = await attachReviewManifest(
-+      {
-+        id: 'imp-fail-merge',
-+        status: 'PARSED',
-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-+        createdAt: new Date(),
-+        versions: [],
-+      },
-+      details,
-+      'imp-fail-merge',
-+      'body',
-+      { resolveBlocking: false },
-+    );
-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
-+    vi.mocked(prisma.contentVersion.create).mockRejectedValue(new Error('db failure'));
-+
-+    await expect(
-+      mergeImportCandidateToWorkingDraft({
-+        importId: 'imp-fail-merge',
-+        action: 'create',
-+        acknowledgeUnresolvedReview: true,
-+        unresolvedReviewReason: 'Accepted risk for unresolved reconciliation decisions.',
-+      }),
-+    ).rejects.toThrow('db failure');
-+
-+    const overrideEvents = vi
-+      .mocked(recordContentEvent)
-+      .mock.calls.filter(
-+        (call) =>
-+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
-+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
-+      );
-+    expect(overrideEvents).toHaveLength(0);
-+  });
-+
-+  it('records exactly one override audit event after successful acknowledged merge', async () => {
-+    vi.mocked(recordContentEvent).mockClear();
-+    const details = minimalImportDetails();
-+    const row = await attachReviewManifest(
-+      {
-+        id: 'imp-override-ok',
-+        status: 'PARSED',
-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-+        createdAt: new Date(),
-+        versions: [],
-+      },
-+      details,
-+      'imp-override-ok',
-+      'body',
-+      { resolveBlocking: false },
-+    );
-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
-+    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
-+      id: 'cv-override',
-+      status: 'DRAFT',
-+      draftSlot: 'main',
-+      importId: 'imp-override-ok',
-+      payload: {},
-+      label: null,
-+      changeSummary: null,
-+      createdBy: null,
-+      createdAt: new Date(),
-+      updatedAt: new Date(),
-+      publishedAt: null,
-+      publishSequence: null,
-+    } as never);
-+
-+    await mergeImportCandidateToWorkingDraft({
-+      importId: 'imp-override-ok',
-+      action: 'create',
-+      acknowledgeUnresolvedReview: true,
-+      unresolvedReviewReason: '  Accepted risk for unresolved reconciliation decisions.  ',
+ 
++  it('toImportDetail returns corrupted reconciliation DTO for malformed stored approvals', async () => {
++    const candidate = fixtureImportDetails();
++    const payload = buildImportCandidatePayload({
++      rawDocumentText: 'cv body',
++      parserVersion: '1',
++      details: candidate,
++      sections: [],
++      importWarnings: [],
 +    });
-+
-+    const overrideEvents = vi
-+      .mocked(recordContentEvent)
-+      .mock.calls.filter(
-+        (call) =>
-+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
-+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
-+      );
-+    expect(overrideEvents).toHaveLength(1);
-+    expect(overrideEvents[0]?.[0]).toMatchObject({
-+      versionId: 'cv-override',
-+      payload: expect.objectContaining({
-+        reason: 'Accepted risk for unresolved reconciliation decisions.',
-+      }),
++    const { envelope } = await generateImportReviewManifest({
++      importId: 'imp-corrupt',
++      sourceFileName: 'cv.docx',
++      sourceTextHash: payload.sourceTextHash,
++      candidate,
 +    });
-+  });
-+
-+  it('does not record override audit event when unresolved blocking count is zero', async () => {
-+    vi.mocked(recordContentEvent).mockClear();
-+    const details = minimalImportDetails();
-+    const row = await attachReviewManifest(
-+      {
-+        id: 'imp-no-override',
-+        status: 'PARSED',
-+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-+        createdAt: new Date(),
-+        versions: [],
++    const createdAt = new Date('2026-01-02T03:04:05.000Z');
++    const updatedAt = new Date('2026-01-03T03:04:05.000Z');
++    const row = {
++      id: 'imp-corrupt',
++      uploadedFileId: 'up1',
++      status: 'PARSED' as const,
++      parserVersion: '1',
++      warnings: [],
++      rawPreviewPath: null,
++      rawExtract: null,
++      candidatePayload: payload as unknown as Prisma.JsonValue,
++      reviewManifest: envelope,
++      reviewApprovals: { corrupted: true },
++      createdAt,
++      updatedAt,
++      uploadedFile: {
++        id: 'up1',
++        originalName: 'cv.docx',
++        storedPath: '/files/cv.docx',
++        mimeType: 'application/whatever',
++        sizeBytes: 10,
++        sha256: 'abc',
++        sourceFormat: 'DOCX' as const,
++        uploadedAt: createdAt,
 +      },
-+      details,
-+      'imp-no-override',
-+    );
-+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
-+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
-+    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
-+      id: 'cv-no-override',
-+      status: 'DRAFT',
-+      draftSlot: 'main',
-+      importId: 'imp-no-override',
-+      payload: {},
-+      label: null,
-+      changeSummary: null,
-+      createdBy: null,
-+      createdAt: new Date(),
-+      updatedAt: new Date(),
-+      publishedAt: null,
-+      publishSequence: null,
-+    } as never);
-+
-+    await mergeImportCandidateToWorkingDraft({
-+      importId: 'imp-no-override',
-+      action: 'create',
-+      acknowledgeUnresolvedReview: true,
-+      unresolvedReviewReason: 'Should not be used when nothing is unresolved.',
-+    });
-+
-+    const overrideEvents = vi
-+      .mocked(recordContentEvent)
-+      .mock.calls.filter(
-+        (call) =>
-+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
-+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
-+      );
-+    expect(overrideEvents).toHaveLength(0);
++      versions: [],
++    };
++    const detail = toImportDetail(row);
++    expect(detail.candidateReconcileReview).not.toBeNull();
++    expect(detail.candidateReconcileReview!.loadError?.code).toBe('REVIEW_APPROVALS_INVALID');
++    expect(detail.candidateReconcileReview!.mergeReviewBlocked).toBe(true);
++    expect(detail.candidateReconcileReview!.hasManifest).toBe(true);
 +  });
- });
++
++  it('buildImportCandidateReconcileReview returns stale approvals load error without throwing', async () => {
++    const candidate = fixtureImportDetails();
++    const payload = buildImportCandidatePayload({
++      rawDocumentText: 'cv body',
++      parserVersion: '1',
++      details: candidate,
++      sections: [],
++      importWarnings: [],
++    });
++    const { envelope } = await generateImportReviewManifest({
++      importId: 'imp-stale',
++      sourceFileName: 'cv.docx',
++      sourceTextHash: payload.sourceTextHash,
++      candidate,
++    });
++    const staleApprovals = toStoredApprovalsEnvelope({
++      manifestRevision: 'deadbeefdeadbeefdeadbeefdeadbeef',
++      approvals: [],
++    });
++    const review = buildImportCandidateReconcileReview({
++      reviewManifest: envelope,
++      reviewApprovals: staleApprovals,
++    });
++    expect(review).not.toBeNull();
++    expect(review!.loadError?.code).toBe('REVIEW_APPROVALS_STALE');
++    expect(review!.mergeReviewBlocked).toBe(true);
++  });
++
++  it('buildImportCandidateReconcileReview does not swallow unknown programming errors', async () => {
++    const spy = vi.spyOn(reconcileModule, 'loadImportReviewStateFromRow').mockImplementation(() => {
++      throw new Error('unexpected programming failure');
++    });
++    expect(() =>
++      buildImportCandidateReconcileReview({
++        reviewManifest: { storageVersion: 1 },
++        reviewApprovals: null,
++      }),
++    ).toThrow('unexpected programming failure');
++    spy.mockRestore();
++  });
++
+   it('toImportDetail has null candidateReview for malformed candidatePayload', () => {
+     const createdAt = new Date('2026-01-02T03:04:05.000Z');
+     const updatedAt = new Date('2026-01-03T03:04:05.000Z');

--- a/prisma/migrations/20260612140000_import_candidate_review/migration.sql
+++ b/prisma/migrations/20260612140000_import_candidate_review/migration.sql
@@ -1,0 +1,5 @@
+-- Add candidate review manifest and approvals storage to ContentImport.
+-- Rollback: ALTER TABLE "ContentImport" DROP COLUMN "reviewManifest", DROP COLUMN "reviewApprovals";
+
+ALTER TABLE "ContentImport" ADD COLUMN "reviewManifest" JSONB;
+ALTER TABLE "ContentImport" ADD COLUMN "reviewApprovals" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,10 @@ model ContentImport {
   rawExtract       Json?
   /// Parsed candidate payload for review — never the published/draft SiteContent until merged in a later phase.
   candidatePayload Json?
+  /// Candidate-vs-baseline reconciliation manifest (`CandidateReviewManifest` envelope).
+  reviewManifest Json?
+  /// Explicit admin approvals for reconciliation decisions.
+  reviewApprovals Json?
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
   versions         ContentVersion[]

--- a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+++ b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
@@ -276,6 +276,19 @@ export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }: 
     );
   }
 
+  if (reconcile.loadError) {
+    return (
+      <div className="card p-4 space-y-3">
+        <h2 className="text-lg font-semibold text-foreground">Candidate reconciliation review</h2>
+        <div className="rounded border border-error/40 bg-error/10 px-3 py-2 text-sm text-foreground space-y-1">
+          <p className="font-medium">Stored reconciliation data is invalid.</p>
+          <p>Merge is blocked. Reprocess the import or repair the stored review data.</p>
+          <p className="text-xs text-muted">{reconcile.loadError.message}</p>
+        </div>
+      </div>
+    );
+  }
+
   const pub = reconcile.accounting as {
     publications?: { candidateTotal?: number; baselineTotal?: number };
     awards?: { candidateTotal?: number; baselineTotal?: number };

--- a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+++ b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
@@ -154,6 +154,29 @@ function decisionControls(
   );
 }
 
+function approvalBadgeStatus(
+  draftApproval: LocalApproval | undefined,
+  serverApproval: LocalApproval | undefined,
+): 'pending' | 'unsaved' | 'saved' {
+  if (draftApproval) {
+    return 'unsaved';
+  }
+  if (serverApproval) {
+    return 'saved';
+  }
+  return 'pending';
+}
+
+function ApprovalStatusBadge({ status }: { status: 'pending' | 'unsaved' | 'saved' }) {
+  if (status === 'saved') {
+    return <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>;
+  }
+  if (status === 'unsaved') {
+    return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">unsaved</span>;
+  }
+  return <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>;
+}
+
 export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }: Props) {
   const [draftApprovals, setDraftApprovals] = useState<LocalApproval[]>([]);
   const [saving, setSaving] = useState(false);
@@ -308,23 +331,22 @@ export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }: 
           <h3 className="text-sm font-medium text-foreground">{sectionLabel(section)}</h3>
           <div className="space-y-3">
             {decisions.map((decision) => {
+              const serverApproval = serverApprovals.find((a) => a.decisionId === decision.decisionId);
+              const draftApproval = draftApprovals.find((a) => a.decisionId === decision.decisionId);
               const current = effectiveApprovals.get(decision.decisionId);
-              const isCluster = Boolean(decision.relatedExistingIds && decision.relatedExistingIds.length > 0);
-              const clusterMembers = isCluster
-                ? [decision.existingId!, ...(decision.relatedExistingIds ?? [])]
-                : [];
-              const resolved = Boolean(current);
+              const clusterMemberIds = [decision.existingId, ...(decision.relatedExistingIds ?? [])].filter(
+                (id): id is string => Boolean(id),
+              );
+              const isCluster = clusterMemberIds.length >= 2;
+              const clusterMembers = isCluster ? clusterMemberIds : [];
+              const approvalStatus = approvalBadgeStatus(draftApproval, serverApproval as LocalApproval | undefined);
 
               return (
                 <div key={decision.decisionId} className="rounded border border-primary/15 p-3 text-xs space-y-2">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-medium text-foreground">{decision.action}</span>
                     <span className="text-muted">confidence: {decision.confidence}</span>
-                    {resolved ? (
-                      <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>
-                    ) : (
-                      <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>
-                    )}
+                    <ApprovalStatusBadge status={approvalStatus} />
                   </div>
                   <p className="text-foreground">{decision.reason}</p>
                   {decision.existingId ? (

--- a/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
+++ b/src/app/admin/imports/ImportCandidateReconcilePanel.tsx
@@ -1,0 +1,394 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+
+import type { ImportCandidateReconcileReviewModel } from './importDetailTypes';
+
+type ApprovalAction = 'preserve-existing' | 'approve-removal' | 'skip';
+
+type LocalApproval = {
+  decisionId: string;
+  approvedAction: ApprovalAction;
+  selectedExistingId?: string;
+};
+
+type Props = {
+  importId: string;
+  reconcile: ImportCandidateReconcileReviewModel | null | undefined;
+  onSaved: () => void;
+};
+
+function sectionLabel(section: string): string {
+  switch (section) {
+    case 'publications':
+      return 'Publications';
+    case 'awards':
+      return 'Awards';
+    case 'patents':
+      return 'Patents (advisory)';
+    case 'research':
+      return 'Research (advisory)';
+    default:
+      return section;
+  }
+}
+
+function isResolvableDecision(decision: ImportCandidateReconcileReviewModel['decisions'][number]): boolean {
+  return decision.action === 'manual-review' || decision.action === 'remove-artifact';
+}
+
+function isAdvisorySection(section: string): boolean {
+  return section === 'patents' || section === 'research';
+}
+
+function decisionControls(
+  decision: ImportCandidateReconcileReviewModel['decisions'][number],
+  clusterMembers: string[],
+  clusterSelections: Record<string, string>,
+  setClusterSelections: React.Dispatch<React.SetStateAction<Record<string, string>>>,
+  setApproval: (approval: LocalApproval) => void,
+): React.ReactNode {
+  const isCluster = clusterMembers.length > 1;
+  const isArtifact = decision.action === 'remove-artifact' && !isCluster;
+
+  if (isCluster) {
+    return (
+      <div className="flex flex-wrap gap-2 items-center">
+        <select
+          className="input text-xs"
+          value={clusterSelections[decision.decisionId] ?? clusterMembers[0] ?? ''}
+          onChange={(e) =>
+            setClusterSelections((s) => ({ ...s, [decision.decisionId]: e.target.value }))
+          }
+        >
+          {clusterMembers.map((id) => (
+            <option key={id} value={id}>
+              Preserve {id}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() =>
+            setApproval({
+              decisionId: decision.decisionId,
+              approvedAction: 'preserve-existing',
+              selectedExistingId: clusterSelections[decision.decisionId] ?? clusterMembers[0],
+            })
+          }
+        >
+          Preserve selected
+        </button>
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() =>
+            setApproval({ decisionId: decision.decisionId, approvedAction: 'approve-removal' })
+          }
+        >
+          Remove entire cluster
+        </button>
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() => setApproval({ decisionId: decision.decisionId, approvedAction: 'skip' })}
+        >
+          Skip
+        </button>
+      </div>
+    );
+  }
+
+  if (isArtifact) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() =>
+            setApproval({ decisionId: decision.decisionId, approvedAction: 'approve-removal' })
+          }
+        >
+          Approve removal
+        </button>
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() => setApproval({ decisionId: decision.decisionId, approvedAction: 'skip' })}
+        >
+          Skip
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        className="btn-secondary text-xs"
+        onClick={() =>
+          setApproval({ decisionId: decision.decisionId, approvedAction: 'preserve-existing' })
+        }
+      >
+        Preserve existing
+      </button>
+      <button
+        type="button"
+        className="btn-secondary text-xs"
+        onClick={() =>
+          setApproval({ decisionId: decision.decisionId, approvedAction: 'approve-removal' })
+        }
+      >
+        Approve removal
+      </button>
+      <button
+        type="button"
+        className="btn-secondary text-xs"
+        onClick={() => setApproval({ decisionId: decision.decisionId, approvedAction: 'skip' })}
+      >
+        Skip
+      </button>
+    </div>
+  );
+}
+
+export function ImportCandidateReconcilePanel({ importId, reconcile, onSaved }: Props) {
+  const [draftApprovals, setDraftApprovals] = useState<LocalApproval[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedMsg, setSavedMsg] = useState<string | null>(null);
+  const [clusterSelections, setClusterSelections] = useState<Record<string, string>>({});
+
+  const serverApprovals = useMemo(() => reconcile?.approvals ?? [], [reconcile?.approvals]);
+
+  const effectiveApprovals = useMemo(() => {
+    const map = new Map<string, LocalApproval>();
+    for (const a of serverApprovals) {
+      map.set(a.decisionId, a as LocalApproval);
+    }
+    for (const a of draftApprovals) {
+      map.set(a.decisionId, a);
+    }
+    return map;
+  }, [serverApprovals, draftApprovals]);
+
+  const setApproval = useCallback((approval: LocalApproval) => {
+    setDraftApprovals((prev) => {
+      const next = prev.filter((a) => a.decisionId !== approval.decisionId);
+      next.push(approval);
+      return next;
+    });
+    setSavedMsg(null);
+  }, []);
+
+  const pendingDecisions = useMemo(() => {
+    if (!reconcile?.hasManifest) {
+      return [];
+    }
+    return reconcile.decisions.filter((d) => isResolvableDecision(d) && !isAdvisorySection(d.section));
+  }, [reconcile]);
+
+  const grouped = useMemo(() => {
+    const sections = new Map<string, typeof pendingDecisions>();
+    for (const d of pendingDecisions) {
+      const list = sections.get(d.section) ?? [];
+      list.push(d);
+      sections.set(d.section, list);
+    }
+    return sections;
+  }, [pendingDecisions]);
+
+  const saveAll = useCallback(async () => {
+    if (!reconcile?.manifestRevision) {
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setSavedMsg(null);
+    const approvals = Array.from(effectiveApprovals.values());
+    try {
+      const res = await fetch(`/api/admin/imports/${importId}/review-approvals`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          manifestRevision: reconcile.manifestRevision,
+          approvals,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setError(json.message || json.error || 'Failed to save approvals');
+        return;
+      }
+      setDraftApprovals([]);
+      setSavedMsg('Reconciliation approvals saved.');
+      onSaved();
+    } catch {
+      setError('Failed to save approvals');
+    } finally {
+      setSaving(false);
+    }
+  }, [effectiveApprovals, importId, onSaved, reconcile?.manifestRevision]);
+
+  if (!reconcile) {
+    return (
+      <div className="card p-4 space-y-2">
+        <h2 className="text-lg font-semibold text-foreground">Candidate reconciliation review</h2>
+        <p className="text-sm text-muted">No reconciliation manifest is available for this import yet.</p>
+      </div>
+    );
+  }
+
+  if (!reconcile.hasManifest) {
+    return (
+      <div className="card p-4 space-y-2">
+        <h2 className="text-lg font-semibold text-foreground">Candidate reconciliation review</h2>
+        <p className="text-sm text-muted">
+          Manifest not generated. Re-process the import or merge to lazily generate reconciliation data.
+        </p>
+      </div>
+    );
+  }
+
+  const pub = reconcile.accounting as {
+    publications?: { candidateTotal?: number; baselineTotal?: number };
+    awards?: { candidateTotal?: number; baselineTotal?: number };
+  } | null;
+
+  return (
+    <div className="card p-4 space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold text-foreground">Candidate reconciliation review</h2>
+        <p className="text-xs text-muted">
+          Approvals affect the proposed draft merge only — they do not publish content directly.
+          Unresolved publication/award decisions block merge unless explicitly acknowledged with a reason.
+        </p>
+      </div>
+
+      <div className="grid gap-2 text-xs sm:grid-cols-2">
+        <div className="rounded border border-primary/15 p-2">
+          <p className="text-muted">Baseline</p>
+          <p className="text-foreground">{reconcile.baseline?.label ?? reconcile.baseline?.sourceType}</p>
+        </div>
+        <div className="rounded border border-primary/15 p-2">
+          <p className="text-muted">Unresolved blocking decisions</p>
+          <p className={reconcile.mergeReviewBlocked ? 'text-warning font-medium' : 'text-foreground'}>
+            {reconcile.unresolvedBlockingCount}
+          </p>
+        </div>
+        <div className="rounded border border-primary/15 p-2">
+          <p className="text-muted">Candidate publications / baseline</p>
+          <p className="text-foreground">
+            {pub?.publications?.candidateTotal ?? '—'} / {pub?.publications?.baselineTotal ?? '—'}
+          </p>
+        </div>
+        <div className="rounded border border-primary/15 p-2">
+          <p className="text-muted">Candidate awards / baseline</p>
+          <p className="text-foreground">
+            {pub?.awards?.candidateTotal ?? '—'} / {pub?.awards?.baselineTotal ?? '—'}
+          </p>
+        </div>
+      </div>
+
+      {reconcile.mergeReviewBlocked ? (
+        <div className="rounded border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-foreground">
+          Merge is blocked until all publication and award reconciliation decisions are resolved or explicitly
+          overridden at merge time.
+        </div>
+      ) : null}
+
+      {error ? <div className="text-sm text-error">{error}</div> : null}
+      {savedMsg ? <div className="text-sm text-success">{savedMsg}</div> : null}
+
+      {[...grouped.entries()].map(([section, decisions]) => (
+        <div key={section} className="space-y-2">
+          <h3 className="text-sm font-medium text-foreground">{sectionLabel(section)}</h3>
+          <div className="space-y-3">
+            {decisions.map((decision) => {
+              const current = effectiveApprovals.get(decision.decisionId);
+              const isCluster = Boolean(decision.relatedExistingIds && decision.relatedExistingIds.length > 0);
+              const clusterMembers = isCluster
+                ? [decision.existingId!, ...(decision.relatedExistingIds ?? [])]
+                : [];
+              const resolved = Boolean(current);
+
+              return (
+                <div key={decision.decisionId} className="rounded border border-primary/15 p-3 text-xs space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-foreground">{decision.action}</span>
+                    <span className="text-muted">confidence: {decision.confidence}</span>
+                    {resolved ? (
+                      <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">saved</span>
+                    ) : (
+                      <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">pending</span>
+                    )}
+                  </div>
+                  <p className="text-foreground">{decision.reason}</p>
+                  {decision.existingId ? (
+                    <p className="text-muted">Baseline id: {decision.existingId}</p>
+                  ) : null}
+                  {decision.candidateId ? (
+                    <p className="text-muted">Candidate id: {decision.candidateId}</p>
+                  ) : null}
+                  {isCluster ? (
+                    <p className="text-muted">Cluster members: {clusterMembers.join(', ')}</p>
+                  ) : null}
+
+                  {decisionControls(
+                    decision,
+                    clusterMembers,
+                    clusterSelections,
+                    setClusterSelections,
+                    setApproval,
+                  )}
+                  {current ? (
+                    <p className="text-muted">
+                      Current approval: {current.approvedAction}
+                      {current.selectedExistingId ? ` (${current.selectedExistingId})` : ''}
+                    </p>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      {reconcile.decisions.filter((d) => isAdvisorySection(d.section)).length > 0 ? (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium text-foreground">Advisory sections</h3>
+          {reconcile.decisions
+            .filter((d) => isAdvisorySection(d.section))
+            .map((d) => (
+              <div key={d.decisionId} className="rounded border border-primary/15 p-3 text-xs">
+                <p className="font-medium text-foreground">{sectionLabel(d.section)}</p>
+                <p className="text-foreground">{d.reason}</p>
+                {d.affectedCount !== undefined && d.affectedCount !== null ? (
+                  <p className="text-muted">Affected records: {d.affectedCount}</p>
+                ) : null}
+                <p className="text-muted">Informational only — no approval controls.</p>
+              </div>
+            ))}
+        </div>
+      ) : null}
+
+      {pendingDecisions.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          <button type="button" className="btn-primary text-sm" disabled={saving} onClick={() => void saveAll()}>
+            {saving ? 'Saving…' : 'Save reconciliation approvals'}
+          </button>
+          {reconcile.manifestRevision ? (
+            <span className="text-xs text-muted self-center">
+              manifest revision: {reconcile.manifestRevision.slice(0, 8)}…
+            </span>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-sm text-muted">No publication or award decisions require reconciliation approval.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/imports/ImportMergeDraftCard.tsx
+++ b/src/app/admin/imports/ImportMergeDraftCard.tsx
@@ -19,7 +19,12 @@ type Props = {
   merging: boolean;
   onMerge: (
     action: 'create' | 'replace',
-    opts: { mergeMode: 'safe_update' | 'full_replace'; acknowledgeHighRisk: boolean },
+    opts: {
+      mergeMode: 'safe_update' | 'full_replace';
+      acknowledgeHighRisk: boolean;
+      acknowledgeUnresolvedReview?: boolean;
+      unresolvedReviewReason?: string;
+    },
   ) => void;
 };
 
@@ -182,19 +187,31 @@ function DraftStatusNote({ hasDraft, isMerged }: { hasDraft: boolean; isMerged: 
 
 export function ImportMergeDraftCard({ imp, review, hasDraft, merging, onMerge }: Props) {
   const hint = imp.candidateReview?.reviewHint;
+  const reconcile = imp.candidateReconcileReview;
   const [mergeMode, setMergeMode] = useState<'safe_update' | 'full_replace'>('safe_update');
   const [acknowledgeHighRisk, setAcknowledgeHighRisk] = useState(false);
+  const [acknowledgeUnresolvedReview, setAcknowledgeUnresolvedReview] = useState(false);
+  const [unresolvedReviewReason, setUnresolvedReviewReason] = useState('');
 
   const safety = review?.mergeSafety;
   const needsAck = Boolean(safety?.fullReplaceRequiresAck);
+  const reviewBlocked = Boolean(reconcile?.mergeReviewBlocked);
   const fullReplaceBlocked = mergeMode === 'full_replace' && needsAck && !acknowledgeHighRisk;
+  const reviewOverrideBlocked =
+    reviewBlocked && (!acknowledgeUnresolvedReview || unresolvedReviewReason.trim().length < 8);
+  const mergeDisabled = fullReplaceBlocked || reviewOverrideBlocked;
 
   const candidateParserVersion = imp.candidateReview?.parserVersion;
   const isStaleParser = Boolean(candidateParserVersion && candidateParserVersion !== PARSER_VERSION);
 
   const mergeOpts = useMemo(
-    () => ({ mergeMode, acknowledgeHighRisk: mergeMode === 'full_replace' && acknowledgeHighRisk }),
-    [mergeMode, acknowledgeHighRisk],
+    () => ({
+      mergeMode,
+      acknowledgeHighRisk: mergeMode === 'full_replace' && acknowledgeHighRisk,
+      acknowledgeUnresolvedReview: reviewBlocked && acknowledgeUnresolvedReview,
+      unresolvedReviewReason: reviewBlocked ? unresolvedReviewReason.trim() : undefined,
+    }),
+    [mergeMode, acknowledgeHighRisk, reviewBlocked, acknowledgeUnresolvedReview, unresolvedReviewReason],
   );
 
   return (
@@ -220,6 +237,33 @@ export function ImportMergeDraftCard({ imp, review, hasDraft, merging, onMerge }
         />
       ) : null}
 
+      {reviewBlocked ? (
+        <div className="rounded border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-foreground space-y-2">
+          <p>
+            <strong className="text-warning">Reconciliation review required:</strong>{' '}
+            {reconcile?.unresolvedBlockingCount ?? 0} publication/award decision(s) remain unresolved. Resolve them in
+            the reconciliation panel above, or acknowledge override below.
+          </p>
+          <label className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              checked={acknowledgeUnresolvedReview}
+              onChange={(e) => setAcknowledgeUnresolvedReview(e.target.checked)}
+            />
+            <span>I acknowledge merging with unresolved reconciliation decisions.</span>
+          </label>
+          {acknowledgeUnresolvedReview ? (
+            <textarea
+              className="input w-full text-xs"
+              rows={2}
+              placeholder="Reason for override (required, min 8 characters)"
+              value={unresolvedReviewReason}
+              onChange={(e) => setUnresolvedReviewReason(e.target.value)}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
       <p className="font-medium text-foreground">Merge into working draft</p>
       <p className="text-xs text-muted">
         Updates the <strong>working draft</strong> only — visitors still see the published site until you publish from Site
@@ -228,7 +272,7 @@ export function ImportMergeDraftCard({ imp, review, hasDraft, merging, onMerge }
       <div className="flex flex-wrap gap-3">
         <button
           type="button"
-          disabled={merging || hasDraft || fullReplaceBlocked}
+          disabled={merging || hasDraft || mergeDisabled}
           onClick={() => onMerge('create', mergeOpts)}
           className="btn-primary px-4 py-2 text-sm disabled:opacity-40"
         >
@@ -236,7 +280,7 @@ export function ImportMergeDraftCard({ imp, review, hasDraft, merging, onMerge }
         </button>
         <button
           type="button"
-          disabled={merging || !hasDraft || fullReplaceBlocked}
+          disabled={merging || !hasDraft || mergeDisabled}
           onClick={() => onMerge('replace', mergeOpts)}
           className="btn-secondary px-4 py-2 text-sm disabled:opacity-40"
         >

--- a/src/app/admin/imports/[id]/page.tsx
+++ b/src/app/admin/imports/[id]/page.tsx
@@ -95,7 +95,12 @@ export default function AdminImportDetailPage() {
   const merge = useCallback(
     async (
       action: 'create' | 'replace',
-      opts: { mergeMode: 'safe_update' | 'full_replace'; acknowledgeHighRisk: boolean },
+      opts: {
+        mergeMode: 'safe_update' | 'full_replace';
+        acknowledgeHighRisk: boolean;
+        acknowledgeUnresolvedReview?: boolean;
+        unresolvedReviewReason?: string;
+      },
     ) => {
       setMerging(true);
       setMergeMsg(null);
@@ -109,6 +114,8 @@ export default function AdminImportDetailPage() {
             action,
             mergeMode: opts.mergeMode,
             acknowledgeHighRisk: opts.acknowledgeHighRisk ? true : undefined,
+            acknowledgeUnresolvedReview: opts.acknowledgeUnresolvedReview ? true : undefined,
+            unresolvedReviewReason: opts.unresolvedReviewReason,
           }),
         });
         const data = await res.json();
@@ -199,6 +206,7 @@ export default function AdminImportDetailPage() {
         merging={merging}
         mergeMsg={mergeMsg}
         error={error}
+        onReload={() => void load()}
         onMerge={(a, o) => void merge(a, o)}
       />
     </div>

--- a/src/app/admin/imports/importDetailBody.tsx
+++ b/src/app/admin/imports/importDetailBody.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import React from 'react';
 
 import { ImportAiReviewAssistantPanel } from './ImportAiReviewAssistantPanel';
+import { ImportCandidateReconcilePanel } from './ImportCandidateReconcilePanel';
 import { ImportCandidateReviewPanels } from './ImportCandidateReviewPanels';
 import { ImportCandidateSummaryCard } from './ImportCandidateSummaryCard';
 import type { ImportDetailModel, ReviewBaselineQuery, ReviewPayloadModel } from './importDetailTypes';
@@ -20,9 +21,15 @@ type Props = {
   merging: boolean;
   mergeMsg: string | null;
   error: string | null;
+  onReload: () => void;
   onMerge: (
     action: 'create' | 'replace',
-    opts: { mergeMode: 'safe_update' | 'full_replace'; acknowledgeHighRisk: boolean },
+    opts: {
+      mergeMode: 'safe_update' | 'full_replace';
+      acknowledgeHighRisk: boolean;
+      acknowledgeUnresolvedReview?: boolean;
+      unresolvedReviewReason?: string;
+    },
   ) => void;
 };
 
@@ -34,6 +41,7 @@ export function ImportDetailBody({
   merging,
   mergeMsg,
   error,
+  onReload,
   onMerge,
 }: Props) {
   return (
@@ -64,6 +72,12 @@ export function ImportDetailBody({
         <ImportCandidateSummaryCard imp={imp} />
 
         <ImportCandidateReviewPanels imp={imp} review={review} />
+
+        <ImportCandidateReconcilePanel
+          importId={imp.id}
+          reconcile={imp.candidateReconcileReview}
+          onSaved={onReload}
+        />
 
         {review ? <ImportReviewWarningsPanel review={review} /> : null}
 

--- a/src/app/admin/imports/importDetailTypes.ts
+++ b/src/app/admin/imports/importDetailTypes.ts
@@ -72,6 +72,10 @@ export type ImportCandidateReconcileReviewModel = {
   unresolvedBlockingCount: number;
   mergeReviewBlocked: boolean;
   advisoryOnly: boolean;
+  loadError?: {
+    code: 'REVIEW_MANIFEST_INVALID' | 'REVIEW_APPROVALS_INVALID' | 'REVIEW_APPROVALS_STALE';
+    message: string;
+  } | null;
 };
 
 export type ImportDetailModel = {

--- a/src/app/admin/imports/importDetailTypes.ts
+++ b/src/app/admin/imports/importDetailTypes.ts
@@ -38,6 +38,42 @@ export type ImportCandidateReviewModel = {
   parserWarnings: Array<{ code?: string; path?: string; message: string; severity: string }>;
 };
 
+export type ImportCandidateReconcileReviewModel = {
+  hasManifest: boolean;
+  manifestRevision: string | null;
+  sourceTextHash: string | null;
+  baseline: {
+    sourceType: string;
+    versionId?: string | null;
+    publishSequence?: number | null;
+    label?: string | null;
+  } | null;
+  generatedAt: string | null;
+  importSource: string | null;
+  decisions: Array<{
+    decisionId: string;
+    section: string;
+    candidateId?: string;
+    existingId?: string;
+    relatedExistingIds?: string[];
+    action: string;
+    reason: string;
+    confidence: string;
+    affectedCount?: number;
+  }>;
+  accounting: Record<string, unknown> | null;
+  analysisAccounting: Record<string, unknown> | null;
+  approvals: Array<{
+    decisionId: string;
+    approvedAction: string;
+    selectedExistingId?: string;
+  }>;
+  approvalsUpdatedAt: string | null;
+  unresolvedBlockingCount: number;
+  mergeReviewBlocked: boolean;
+  advisoryOnly: boolean;
+};
+
 export type ImportDetailModel = {
   id: string;
   status: string;
@@ -52,6 +88,7 @@ export type ImportDetailModel = {
   } | null;
   /** Present for envelope `candidatePayload` (from GET import / review). */
   candidateReview?: ImportCandidateReviewModel | null;
+  candidateReconcileReview?: ImportCandidateReconcileReviewModel | null;
 };
 
 export type ImportReviewProvenanceModel = {

--- a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
+++ b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
@@ -38,7 +38,8 @@ function mergeErrorResponse(e: ImportMergeError): NextResponse {
     e.code === 'REVIEW_BLOCKED' ||
     e.code === 'REVIEW_MANIFEST_MISSING' ||
     e.code === 'REVIEW_MANIFEST_STALE' ||
-    e.code === 'REVIEW_APPROVALS_STALE'
+    e.code === 'REVIEW_APPROVALS_STALE' ||
+    e.code === 'REVIEW_APPROVALS_INVALID'
   ) {
     status = 422;
   }

--- a/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
+++ b/src/app/api/admin/imports/[id]/merge-to-draft/route.ts
@@ -19,6 +19,8 @@ const bodySchema = z
     action: z.enum(['create', 'replace']),
     mergeMode: z.enum(['safe_update', 'full_replace']).optional(),
     acknowledgeHighRisk: z.boolean().optional(),
+    acknowledgeUnresolvedReview: z.boolean().optional(),
+    unresolvedReviewReason: z.string().max(2000).nullable().optional(),
     changeSummary: z.string().max(2000).nullable().optional(),
   })
   .strict();
@@ -29,7 +31,15 @@ function mergeErrorResponse(e: ImportMergeError): NextResponse {
   let status = 400;
   if (e.code === 'IMPORT_NOT_FOUND') {
     status = 404;
-  } else if (e.code === 'MERGE_VALIDATION_FAILED' || e.code === 'INVALID_CANDIDATE' || e.code === 'MERGE_ACK_REQUIRED') {
+  } else if (
+    e.code === 'MERGE_VALIDATION_FAILED' ||
+    e.code === 'INVALID_CANDIDATE' ||
+    e.code === 'MERGE_ACK_REQUIRED' ||
+    e.code === 'REVIEW_BLOCKED' ||
+    e.code === 'REVIEW_MANIFEST_MISSING' ||
+    e.code === 'REVIEW_MANIFEST_STALE' ||
+    e.code === 'REVIEW_APPROVALS_STALE'
+  ) {
     status = 422;
   }
   return NextResponse.json({ ok: false, error: e.code, message: e.message }, { status });
@@ -66,6 +76,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
       action: parsed.data.action,
       mergeMode: parsed.data.mergeMode,
       acknowledgeHighRisk: parsed.data.acknowledgeHighRisk,
+      acknowledgeUnresolvedReview: parsed.data.acknowledgeUnresolvedReview,
+      unresolvedReviewReason: parsed.data.unresolvedReviewReason,
       changeSummary: parsed.data.changeSummary,
     });
     return NextResponse.json({

--- a/src/app/api/admin/imports/[id]/review-approvals/route.ts
+++ b/src/app/api/admin/imports/[id]/review-approvals/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST: persist explicit candidate reconciliation approvals for an import.
+ */
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { requireFullAdminAccessForContent } from '@/server/admin/contentWorkflowAccess';
+import { internalErrorResponse } from '@/server/admin/contentWorkflowHttp';
+import { CandidateReviewApprovalError } from '@/server/imports/candidateReviewValidate';
+import { ImportReviewReconcileError } from '@/server/imports/importCandidateReview/reconcile';
+import {
+  ImportReviewApprovalPersistError,
+  saveImportReviewApprovals,
+} from '@/server/imports/importCandidateReview/service';
+import { candidateReviewApprovalSchema } from '@/server/imports/importCandidateReview/storageSchema';
+
+const bodySchema = z
+  .object({
+    manifestRevision: z.string().min(8),
+    approvals: z.array(candidateReviewApprovalSchema),
+  })
+  .strict();
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function persistErrorStatus(code: ImportReviewApprovalPersistError['code']): number {
+  if (code === 'IMPORT_NOT_FOUND') {
+    return 404;
+  }
+  if (code === 'REVIEW_MANIFEST_STALE' || code === 'CONCURRENT_UPDATE') {
+    return 409;
+  }
+  return 422;
+}
+
+function errorResponse(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json({ ok: false, error: code, message }, { status });
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const denied = await requireFullAdminAccessForContent();
+  if (denied) {
+    return denied;
+  }
+  const { id } = await context.params;
+  if (!id) {
+    return errorResponse('BAD_REQUEST', 'Missing id', 400);
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('BAD_REQUEST', 'Invalid JSON body', 400);
+  }
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorResponse('BAD_REQUEST', parsed.error.message, 400);
+  }
+  try {
+    const reviewState = await saveImportReviewApprovals({
+      importId: id,
+      manifestRevision: parsed.data.manifestRevision,
+      approvals: parsed.data.approvals,
+    });
+    return NextResponse.json({ ok: true, candidateReconcileReview: reviewState });
+  } catch (e) {
+    if (e instanceof ImportReviewApprovalPersistError) {
+      return errorResponse(e.code, e.message, persistErrorStatus(e.code));
+    }
+    if (e instanceof CandidateReviewApprovalError) {
+      return errorResponse('REVIEW_APPROVALS_INVALID', e.message, 422);
+    }
+    if (e instanceof ImportReviewReconcileError) {
+      return errorResponse(e.code, e.message, 422);
+    }
+    console.error(e);
+    return internalErrorResponse();
+  }
+}

--- a/src/server/imports/importCandidateReview/baseline.ts
+++ b/src/server/imports/importCandidateReview/baseline.ts
@@ -1,0 +1,73 @@
+import 'server-only';
+
+import { SITE_CONTENT_RAW } from '@/content/defaults';
+import type { SiteContent } from '@/content/schema';
+import { validateSiteContent } from '@/content/validators';
+import { getLatestPublishedVersion, getWorkingDraft } from '@/server/content/contentWorkflowCore';
+import type { CandidateReviewBaselineRef } from '@/server/imports/candidateReviewManifest';
+import {
+  resolveImportReviewBaseline,
+  type ReviewBaselineResolution,
+} from '@/server/imports/reviewBaseline';
+
+export type ImportMergeReviewBaseline = {
+  baseline: SiteContent;
+  baselineRef: CandidateReviewBaselineRef;
+  resolution: ReviewBaselineResolution;
+};
+
+/**
+ * Baseline used for candidate reconciliation — matches merge baseline selection
+ * (working draft when valid, otherwise in-repo canonical).
+ */
+export async function resolveImportMergeReviewBaseline(): Promise<ImportMergeReviewBaseline> {
+  const working = await getWorkingDraft();
+  const published = await getLatestPublishedVersion();
+  const resolution = resolveImportReviewBaseline('auto', {
+    workingDraftPayload: working?.payload ?? null,
+    publishedPayload: published?.payload ?? null,
+    publishedSequence: published?.publishSequence ?? null,
+    publishedVersionId: published?.id ?? null,
+  });
+
+  let versionId: string | null = null;
+  if (resolution.baselineSource === 'working_draft') {
+    versionId = working?.id ?? null;
+  } else if (resolution.baselineSource === 'published') {
+    versionId = published?.id ?? null;
+  }
+
+  const baselineRef: CandidateReviewBaselineRef = {
+    sourceType: resolution.baselineSource,
+    versionId,
+    publishSequence:
+      resolution.baselineSource === 'published' ? (published?.publishSequence ?? null) : null,
+    label: resolution.baselineLabel,
+  };
+
+  return { baseline: resolution.baseline, baselineRef, resolution };
+}
+
+/** Fallback when only canonical is available without DB (tests). */
+export function resolveCanonicalMergeReviewBaseline(): ImportMergeReviewBaseline {
+  const parsed = validateSiteContent(SITE_CONTENT_RAW);
+  if (!parsed.success) {
+    throw new Error('Canonical baseline failed validation.');
+  }
+  const resolution = resolveImportReviewBaseline('canonical', {
+    workingDraftPayload: null,
+    publishedPayload: null,
+    publishedSequence: null,
+    publishedVersionId: null,
+  });
+  return {
+    baseline: parsed.data,
+    baselineRef: {
+      sourceType: 'canonical',
+      versionId: null,
+      publishSequence: null,
+      label: resolution.baselineLabel,
+    },
+    resolution,
+  };
+}

--- a/src/server/imports/importCandidateReview/gate.ts
+++ b/src/server/imports/importCandidateReview/gate.ts
@@ -1,0 +1,32 @@
+import 'server-only';
+
+import type { CandidateReviewDecision, CandidateReviewManifest } from '@/server/imports/candidateReviewManifest';
+
+const RESOLVABLE_ACTIONS = new Set<CandidateReviewDecision['action']>(['manual-review', 'remove-artifact']);
+
+function isBlockingDecision(decision: CandidateReviewDecision): boolean {
+  if (!RESOLVABLE_ACTIONS.has(decision.action)) {
+    return false;
+  }
+  return decision.section === 'publications' || decision.section === 'awards';
+}
+
+export function listBlockingReviewDecisions(manifest: CandidateReviewManifest): CandidateReviewDecision[] {
+  return manifest.decisions.filter(isBlockingDecision);
+}
+
+export function countUnresolvedBlockingDecisions(manifest: CandidateReviewManifest): number {
+  return manifest.accounting.publications.unresolvedManualReview + manifest.accounting.awards.unresolvedManualReview;
+}
+
+export function isImportReviewMergeBlocked(manifest: CandidateReviewManifest): boolean {
+  return countUnresolvedBlockingDecisions(manifest) > 0;
+}
+
+export function approvalsCoverAllBlockingDecisions(
+  manifest: CandidateReviewManifest,
+  approvalDecisionIds: ReadonlySet<string>,
+): boolean {
+  const blocking = listBlockingReviewDecisions(manifest);
+  return blocking.every((d) => approvalDecisionIds.has(d.decisionId));
+}

--- a/src/server/imports/importCandidateReview/generate.ts
+++ b/src/server/imports/importCandidateReview/generate.ts
@@ -1,0 +1,91 @@
+import 'server-only';
+
+import { recordContentEvent } from '@/server/content/contentEvents';
+import { withAppliedAccounting } from '@/server/imports/candidateReviewAccounting';
+import { analyzeCandidateReview } from '@/server/imports/candidateReviewAnalyze';
+import type {
+  CandidateReviewApproval,
+  CandidateReviewManifest,
+} from '@/server/imports/candidateReviewManifest';
+import { resolveImportMergeReviewBaseline } from '@/server/imports/importCandidateReview/baseline';
+import { revisionForManifest } from '@/server/imports/importCandidateReview/revision';
+import {
+  toStoredManifestEnvelope,
+  type StoredReviewManifestEnvelope,
+} from '@/server/imports/importCandidateReview/storageSchema';
+import type { DetailsSchemaType } from '@/validators/detailsSchema';
+
+export type GenerateImportReviewManifestInput = {
+  importId: string;
+  sourceFileName: string;
+  sourceTextHash: string;
+  candidate: DetailsSchemaType;
+};
+
+export type GeneratedImportReviewManifest = {
+  envelope: StoredReviewManifestEnvelope;
+  manifest: CandidateReviewManifest;
+};
+
+export async function generateImportReviewManifest(
+  input: GenerateImportReviewManifestInput,
+): Promise<GeneratedImportReviewManifest> {
+  const { baseline, baselineRef } = await resolveImportMergeReviewBaseline();
+  const manifest = analyzeCandidateReview({
+    candidate: input.candidate,
+    baseline,
+    baselineRef,
+    importId: input.importId,
+    generatedAt: new Date().toISOString(),
+  });
+  const manifestRevision = revisionForManifest(manifest, input.sourceTextHash);
+  const envelope = toStoredManifestEnvelope({
+    manifest,
+    sourceTextHash: input.sourceTextHash,
+    manifestRevision,
+  });
+  return { envelope, manifest };
+}
+
+export function summarizeReviewManifestForAudit(manifest: CandidateReviewManifest): {
+  decisionCount: number;
+  unresolvedPublications: number;
+  unresolvedAwards: number;
+  advisoryPatentDecisions: number;
+  advisoryResearchDecisions: number;
+  accounting: CandidateReviewManifest['accounting'];
+} {
+  return {
+    decisionCount: manifest.decisions.length,
+    unresolvedPublications: manifest.accounting.publications.unresolvedManualReview,
+    unresolvedAwards: manifest.accounting.awards.unresolvedManualReview,
+    advisoryPatentDecisions: manifest.accounting.patents.unresolvedAdvisoryDecisions,
+    advisoryResearchDecisions: manifest.accounting.research.unresolvedAdvisoryDecisions,
+    accounting: manifest.accounting,
+  };
+}
+
+export async function recordImportReviewGeneratedEvent(input: {
+  importId: string;
+  manifestRevision: string;
+  baselineRef: CandidateReviewManifest['baseline'];
+  summary: ReturnType<typeof summarizeReviewManifestForAudit>;
+}): Promise<void> {
+  await recordContentEvent({
+    eventType: 'SYSTEM_NOTE',
+    payload: {
+      kind: 'IMPORT_REVIEW_GENERATED',
+      importId: input.importId,
+      manifestRevision: input.manifestRevision,
+      baseline: input.baselineRef,
+      summary: input.summary,
+    },
+  });
+}
+
+export function applyApprovalsToStoredManifest(
+  manifest: CandidateReviewManifest,
+  approvals: readonly CandidateReviewApproval[],
+): CandidateReviewManifest {
+  return withAppliedAccounting(manifest, approvals);
+}

--- a/src/server/imports/importCandidateReview/reconcile.ts
+++ b/src/server/imports/importCandidateReview/reconcile.ts
@@ -1,0 +1,140 @@
+import 'server-only';
+
+import type { SiteContent } from '@/content/schema';
+import { assertAccountingConsistent } from '@/server/imports/candidateReviewAccounting';
+import { applyCandidateReviewApprovals } from '@/server/imports/candidateReviewApply';
+import type {
+  CandidateReviewApproval,
+  CandidateReviewManifest,
+} from '@/server/imports/candidateReviewManifest';
+import { validateCandidateReviewApprovals } from '@/server/imports/candidateReviewValidate';
+import { resolveImportMergeReviewBaseline } from '@/server/imports/importCandidateReview/baseline';
+import {
+  isImportReviewMergeBlocked,
+  countUnresolvedBlockingDecisions,
+} from '@/server/imports/importCandidateReview/gate';
+import { applyApprovalsToStoredManifest } from '@/server/imports/importCandidateReview/generate';
+import {
+  parseStoredReviewApprovals,
+  parseStoredReviewManifest,
+  type StoredReviewApprovalsEnvelope,
+  type StoredReviewManifestEnvelope,
+} from '@/server/imports/importCandidateReview/storageSchema';
+import type { DetailsSchemaType } from '@/validators/detailsSchema';
+
+export class ImportReviewReconcileError extends Error {
+  constructor(
+    readonly code:
+      | 'REVIEW_MANIFEST_MISSING'
+      | 'REVIEW_MANIFEST_INVALID'
+      | 'REVIEW_MANIFEST_STALE'
+      | 'REVIEW_APPROVALS_STALE'
+      | 'REVIEW_BLOCKED'
+      | 'REVIEW_APPROVALS_INVALID',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ImportReviewReconcileError';
+  }
+}
+
+export type LoadedImportReviewState = {
+  manifestEnvelope: StoredReviewManifestEnvelope;
+  manifest: CandidateReviewManifest;
+  approvalsEnvelope: StoredReviewApprovalsEnvelope | null;
+  approvals: CandidateReviewApproval[];
+};
+
+export function loadImportReviewStateFromRow(row: {
+  reviewManifest: unknown;
+  reviewApprovals: unknown;
+  candidatePayload: unknown;
+}): LoadedImportReviewState | null {
+  const manifestEnvelope = parseStoredReviewManifest(row.reviewManifest);
+  if (!manifestEnvelope) {
+    return null;
+  }
+  const approvalsEnvelope = row.reviewApprovals
+    ? parseStoredReviewApprovals(row.reviewApprovals)
+    : null;
+  const approvals = approvalsEnvelope?.approvals ?? [];
+  let manifest = manifestEnvelope.manifest as CandidateReviewManifest;
+  if (approvals.length > 0) {
+    manifest = applyApprovalsToStoredManifest(manifest, approvals);
+  }
+  return { manifestEnvelope, manifest, approvalsEnvelope, approvals };
+}
+
+export function verifyReviewApprovalsRevision(
+  manifestEnvelope: StoredReviewManifestEnvelope,
+  approvalsEnvelope: StoredReviewApprovalsEnvelope | null,
+): void {
+  if (!approvalsEnvelope) {
+    return;
+  }
+  if (approvalsEnvelope.manifestRevision !== manifestEnvelope.manifestRevision) {
+    throw new ImportReviewReconcileError(
+      'REVIEW_APPROVALS_STALE',
+      'Stored approvals do not match the current review manifest revision.',
+    );
+  }
+}
+
+export function verifyReviewManifestSourceHash(
+  manifestEnvelope: StoredReviewManifestEnvelope,
+  sourceTextHash: string,
+): void {
+  if (manifestEnvelope.sourceTextHash !== sourceTextHash) {
+    throw new ImportReviewReconcileError(
+      'REVIEW_MANIFEST_STALE',
+      'Review manifest was generated for a different source document hash.',
+    );
+  }
+}
+
+export type ReconcileCandidateForMergeInput = {
+  candidate: DetailsSchemaType;
+  baseline?: SiteContent;
+  manifestEnvelope: StoredReviewManifestEnvelope;
+  manifest: CandidateReviewManifest;
+  approvals: readonly CandidateReviewApproval[];
+  acknowledgeUnresolvedReview?: boolean;
+  unresolvedReviewReason?: string | null;
+};
+
+export type ReconcileCandidateForMergeResult = {
+  details: DetailsSchemaType;
+  manifest: CandidateReviewManifest;
+  unresolvedBlockingCount: number;
+};
+
+export async function reconcileCandidateForMerge(
+  input: ReconcileCandidateForMergeInput,
+): Promise<ReconcileCandidateForMergeResult> {
+  const baseline = input.baseline ?? (await resolveImportMergeReviewBaseline()).baseline;
+  validateCandidateReviewApprovals(input.manifest, baseline, input.approvals);
+
+  const appliedManifest = applyApprovalsToStoredManifest(
+    input.manifestEnvelope.manifest as CandidateReviewManifest,
+    input.approvals,
+  );
+  assertAccountingConsistent(appliedManifest);
+
+  const unresolvedBlockingCount = countUnresolvedBlockingDecisions(appliedManifest);
+  if (isImportReviewMergeBlocked(appliedManifest) && !input.acknowledgeUnresolvedReview) {
+    throw new ImportReviewReconcileError(
+      'REVIEW_BLOCKED',
+      `${unresolvedBlockingCount} publication/award reconciliation decision(s) remain unresolved.`,
+    );
+  }
+
+  const { details, manifest } = applyCandidateReviewApprovals(
+    input.candidate,
+    baseline,
+    input.manifestEnvelope.manifest as CandidateReviewManifest,
+    input.approvals,
+  );
+  assertAccountingConsistent(manifest);
+
+  return { details, manifest, unresolvedBlockingCount };
+}

--- a/src/server/imports/importCandidateReview/reconcile.ts
+++ b/src/server/imports/importCandidateReview/reconcile.ts
@@ -48,15 +48,25 @@ export type LoadedImportReviewState = {
 export function loadImportReviewStateFromRow(row: {
   reviewManifest: unknown;
   reviewApprovals: unknown;
-  candidatePayload: unknown;
 }): LoadedImportReviewState | null {
   const manifestEnvelope = parseStoredReviewManifest(row.reviewManifest);
   if (!manifestEnvelope) {
     return null;
   }
-  const approvalsEnvelope = row.reviewApprovals
-    ? parseStoredReviewApprovals(row.reviewApprovals)
-    : null;
+  const approvalsEnvelope =
+    row.reviewApprovals === null || row.reviewApprovals === undefined
+      ? null
+      : parseStoredReviewApprovals(row.reviewApprovals);
+  if (
+    row.reviewApprovals !== null &&
+    row.reviewApprovals !== undefined &&
+    approvalsEnvelope === null
+  ) {
+    throw new ImportReviewReconcileError(
+      'REVIEW_APPROVALS_INVALID',
+      'Stored review approvals are malformed.',
+    );
+  }
   const approvals = approvalsEnvelope?.approvals ?? [];
   let manifest = manifestEnvelope.manifest as CandidateReviewManifest;
   if (approvals.length > 0) {

--- a/src/server/imports/importCandidateReview/revision.ts
+++ b/src/server/imports/importCandidateReview/revision.ts
@@ -1,0 +1,23 @@
+import { createHash } from 'node:crypto';
+
+import type { CandidateReviewManifest } from '@/server/imports/candidateReviewManifest';
+
+/** Stable revision for manifest + approvals concurrency and stale-submission checks. */
+export function computeImportReviewManifestRevision(input: {
+  sourceTextHash: string;
+  decisionIds: readonly string[];
+}): string {
+  const payload = `${input.sourceTextHash}\n${[...input.decisionIds].sort().join('\n')}`;
+  return createHash('sha256').update(payload).digest('hex').slice(0, 32);
+}
+
+export function manifestDecisionIds(manifest: CandidateReviewManifest): string[] {
+  return manifest.decisions.map((d) => d.decisionId);
+}
+
+export function revisionForManifest(manifest: CandidateReviewManifest, sourceTextHash: string): string {
+  return computeImportReviewManifestRevision({
+    sourceTextHash,
+    decisionIds: manifestDecisionIds(manifest),
+  });
+}

--- a/src/server/imports/importCandidateReview/revision.ts
+++ b/src/server/imports/importCandidateReview/revision.ts
@@ -7,7 +7,10 @@ export function computeImportReviewManifestRevision(input: {
   sourceTextHash: string;
   decisionIds: readonly string[];
 }): string {
-  const payload = `${input.sourceTextHash}\n${[...input.decisionIds].sort().join('\n')}`;
+  const payload = JSON.stringify({
+    sourceTextHash: input.sourceTextHash,
+    decisionIds: [...input.decisionIds].sort(),
+  });
   return createHash('sha256').update(payload).digest('hex').slice(0, 32);
 }
 

--- a/src/server/imports/importCandidateReview/service.ts
+++ b/src/server/imports/importCandidateReview/service.ts
@@ -1,0 +1,234 @@
+import 'server-only';
+
+import { Prisma } from '@prisma/client';
+
+import { recordContentEvent } from '@/server/content/contentEvents';
+import { prisma } from '@/server/db/prisma';
+import { getDetailsFromCandidatePayload, parseImportCandidatePayload } from '@/server/imports/candidatePayload/schema';
+import { withAppliedAccounting } from '@/server/imports/candidateReviewAccounting';
+import type { CandidateReviewApproval } from '@/server/imports/candidateReviewManifest';
+import { validateCandidateReviewApprovals } from '@/server/imports/candidateReviewValidate';
+import { resolveImportMergeReviewBaseline } from '@/server/imports/importCandidateReview/baseline';
+import { countUnresolvedBlockingDecisions } from '@/server/imports/importCandidateReview/gate';
+import {
+  generateImportReviewManifest,
+  recordImportReviewGeneratedEvent,
+  summarizeReviewManifestForAudit,
+} from '@/server/imports/importCandidateReview/generate';
+import {
+  loadImportReviewStateFromRow,
+  verifyReviewApprovalsRevision,
+  verifyReviewManifestSourceHash,
+  ImportReviewReconcileError,
+} from '@/server/imports/importCandidateReview/reconcile';
+import { buildImportCandidateReviewStateDto } from '@/server/imports/importCandidateReview/state';
+import {
+  toStoredApprovalsEnvelope,
+  type StoredReviewManifestEnvelope,
+} from '@/server/imports/importCandidateReview/storageSchema';
+import { ImportDomainError } from '@/server/imports/types';
+
+export class ImportReviewApprovalPersistError extends Error {
+  constructor(
+    readonly code:
+      | 'IMPORT_NOT_FOUND'
+      | 'IMPORT_FINALIZED'
+      | 'REVIEW_MANIFEST_MISSING'
+      | 'REVIEW_MANIFEST_STALE'
+      | 'REVIEW_APPROVALS_INVALID'
+      | 'CONCURRENT_UPDATE',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ImportReviewApprovalPersistError';
+  }
+}
+
+export async function persistImportReviewManifest(
+  importId: string,
+  envelope: StoredReviewManifestEnvelope,
+  options?: { clearApprovals?: boolean },
+): Promise<void> {
+  try {
+    await prisma.contentImport.update({
+      where: { id: importId },
+      data: {
+        reviewManifest: envelope as unknown as Prisma.InputJsonValue,
+        ...(options?.clearApprovals ? { reviewApprovals: Prisma.DbNull } : {}),
+      },
+    });
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+      throw new ImportDomainError('IMPORT_NOT_FOUND', 'Import not found.');
+    }
+    throw e;
+  }
+}
+
+export async function generateAndPersistImportReviewManifest(importId: string): Promise<{
+  envelope: StoredReviewManifestEnvelope;
+}> {
+  const row = await prisma.contentImport.findUnique({ where: { id: importId } });
+  if (!row) {
+    throw new ImportDomainError('IMPORT_NOT_FOUND', 'Import not found.');
+  }
+  const envelopePayload = parseImportCandidatePayload(row.candidatePayload);
+  const details = getDetailsFromCandidatePayload(row.candidatePayload);
+  if (!envelopePayload || !details) {
+    throw new ImportReviewReconcileError('REVIEW_MANIFEST_MISSING', 'Import has no candidate payload.');
+  }
+
+  const prior = loadImportReviewStateFromRow(row);
+  const { envelope, manifest } = await generateImportReviewManifest({
+    importId,
+    sourceFileName: details.meta?.sourceFileName ?? 'unknown',
+    sourceTextHash: envelopePayload.sourceTextHash,
+    candidate: details,
+  });
+
+  const clearApprovals =
+    !prior ||
+    prior.manifestEnvelope.manifestRevision !== envelope.manifestRevision ||
+    prior.manifestEnvelope.sourceTextHash !== envelope.sourceTextHash;
+
+  await persistImportReviewManifest(importId, envelope, { clearApprovals });
+
+  const summary = summarizeReviewManifestForAudit(manifest);
+  await recordImportReviewGeneratedEvent({
+    importId,
+    manifestRevision: envelope.manifestRevision,
+    baselineRef: manifest.baseline,
+    summary,
+  });
+
+  return { envelope };
+}
+
+export async function getImportCandidateReviewState(importId: string) {
+  const row = await prisma.contentImport.findUnique({ where: { id: importId } });
+  if (!row) {
+    return null;
+  }
+  const loaded = loadImportReviewStateFromRow(row);
+  if (!loaded) {
+    return buildImportCandidateReviewStateDto({
+      manifestEnvelope: null,
+      manifest: null,
+      approvalsEnvelope: null,
+      approvals: [],
+      unresolvedBlockingCount: 0,
+    });
+  }
+  return buildImportCandidateReviewStateDto({
+    manifestEnvelope: loaded.manifestEnvelope,
+    manifest: loaded.manifest,
+    approvalsEnvelope: loaded.approvalsEnvelope,
+    approvals: loaded.approvals,
+    unresolvedBlockingCount: countUnresolvedBlockingDecisions(loaded.manifest),
+  });
+}
+
+export async function saveImportReviewApprovals(input: {
+  importId: string;
+  manifestRevision: string;
+  approvals: readonly CandidateReviewApproval[];
+}): Promise<ReturnType<typeof getImportCandidateReviewState>> {
+  const row = await prisma.contentImport.findUnique({ where: { id: input.importId } });
+  if (!row) {
+    throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
+  }
+  if (row.status === 'REJECTED' || row.status === 'FAILED') {
+    throw new ImportReviewApprovalPersistError(
+      'IMPORT_FINALIZED',
+      `Import status "${row.status}" does not accept review approval updates.`,
+    );
+  }
+
+  const loaded = loadImportReviewStateFromRow(row);
+  if (!loaded) {
+    throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
+  }
+
+  const { baseline } = await resolveImportMergeReviewBaseline();
+  validateCandidateReviewApprovals(loaded.manifestEnvelope.manifest, baseline, input.approvals);
+
+  if (loaded.manifestEnvelope.manifestRevision !== input.manifestRevision) {
+    throw new ImportReviewApprovalPersistError(
+      'REVIEW_MANIFEST_STALE',
+      'Submitted manifest revision does not match the current import review manifest.',
+    );
+  }
+
+  const envelopePayload = parseImportCandidatePayload(row.candidatePayload);
+  if (envelopePayload) {
+    verifyReviewManifestSourceHash(loaded.manifestEnvelope, envelopePayload.sourceTextHash);
+  }
+
+  const applied = withAppliedAccounting(loaded.manifestEnvelope.manifest, input.approvals);
+  const approvalsEnvelope = toStoredApprovalsEnvelope({
+    manifestRevision: input.manifestRevision,
+    approvals: input.approvals,
+  });
+
+  await prisma.$transaction(async (tx) => {
+    const current = await tx.contentImport.findUnique({ where: { id: input.importId } });
+    if (!current) {
+      throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
+    }
+    const currentLoaded = loadImportReviewStateFromRow(current);
+    if (!currentLoaded) {
+      throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
+    }
+    if (currentLoaded.manifestEnvelope.manifestRevision !== input.manifestRevision) {
+      throw new ImportReviewApprovalPersistError(
+        'CONCURRENT_UPDATE',
+        'Review manifest changed during approval save. Reload and try again.',
+      );
+    }
+
+    await tx.contentImport.update({
+      where: { id: input.importId },
+      data: {
+        reviewApprovals: approvalsEnvelope as unknown as Prisma.InputJsonValue,
+      },
+    });
+  });
+
+  await recordContentEvent({
+    eventType: 'SYSTEM_NOTE',
+    payload: {
+      kind: 'IMPORT_REVIEW_APPROVALS_UPDATED',
+      importId: input.importId,
+      manifestRevision: input.manifestRevision,
+      approvalCount: input.approvals.length,
+      approvals: input.approvals.map((a) => ({
+        decisionId: a.decisionId,
+        approvedAction: a.approvedAction,
+        selectedExistingId: a.selectedExistingId ?? null,
+      })),
+      unresolvedBlockingCount: countUnresolvedBlockingDecisions(applied),
+    },
+  });
+
+  return getImportCandidateReviewState(input.importId);
+}
+
+export async function ensureImportReviewManifest(importId: string): Promise<StoredReviewManifestEnvelope> {
+  const row = await prisma.contentImport.findUnique({ where: { id: importId } });
+  if (!row) {
+    throw new ImportDomainError('IMPORT_NOT_FOUND', 'Import not found.');
+  }
+  const loaded = loadImportReviewStateFromRow(row);
+  if (loaded) {
+    const envelopePayload = parseImportCandidatePayload(row.candidatePayload);
+    if (envelopePayload) {
+      verifyReviewManifestSourceHash(loaded.manifestEnvelope, envelopePayload.sourceTextHash);
+      if (loaded.approvalsEnvelope) {
+        verifyReviewApprovalsRevision(loaded.manifestEnvelope, loaded.approvalsEnvelope);
+      }
+    }
+    return loaded.manifestEnvelope;
+  }
+  const { envelope } = await generateAndPersistImportReviewManifest(importId);
+  return envelope;
+}

--- a/src/server/imports/importCandidateReview/service.ts
+++ b/src/server/imports/importCandidateReview/service.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import type { ImportStatus } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 
 import { recordContentEvent } from '@/server/content/contentEvents';
@@ -27,6 +28,21 @@ import {
   type StoredReviewManifestEnvelope,
 } from '@/server/imports/importCandidateReview/storageSchema';
 import { ImportDomainError } from '@/server/imports/types';
+
+const REVIEW_APPROVAL_ALLOWED_STATUSES = new Set<ImportStatus>(['PARSED', 'NEEDS_REVIEW']);
+
+export function importStatusAcceptsReviewApprovalUpdates(status: ImportStatus): boolean {
+  return REVIEW_APPROVAL_ALLOWED_STATUSES.has(status);
+}
+
+function assertImportStatusAcceptsReviewApprovalUpdates(status: ImportStatus): void {
+  if (!importStatusAcceptsReviewApprovalUpdates(status)) {
+    throw new ImportReviewApprovalPersistError(
+      'IMPORT_FINALIZED',
+      `Import status "${status}" does not accept review approval updates.`,
+    );
+  }
+}
 
 export class ImportReviewApprovalPersistError extends Error {
   constructor(
@@ -137,14 +153,17 @@ export async function saveImportReviewApprovals(input: {
   if (!row) {
     throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
   }
-  if (row.status === 'REJECTED' || row.status === 'FAILED') {
-    throw new ImportReviewApprovalPersistError(
-      'IMPORT_FINALIZED',
-      `Import status "${row.status}" does not accept review approval updates.`,
-    );
-  }
+  assertImportStatusAcceptsReviewApprovalUpdates(row.status);
 
-  const loaded = loadImportReviewStateFromRow(row);
+  let loaded: ReturnType<typeof loadImportReviewStateFromRow>;
+  try {
+    loaded = loadImportReviewStateFromRow(row);
+  } catch (e) {
+    if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
+      throw new ImportReviewApprovalPersistError('REVIEW_APPROVALS_INVALID', e.message);
+    }
+    throw e;
+  }
   if (!loaded) {
     throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
   }
@@ -175,6 +194,7 @@ export async function saveImportReviewApprovals(input: {
     if (!current) {
       throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
     }
+    assertImportStatusAcceptsReviewApprovalUpdates(current.status);
     const currentLoaded = loadImportReviewStateFromRow(current);
     if (!currentLoaded) {
       throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');

--- a/src/server/imports/importCandidateReview/service.ts
+++ b/src/server/imports/importCandidateReview/service.ts
@@ -190,12 +190,28 @@ export async function saveImportReviewApprovals(input: {
   });
 
   await prisma.$transaction(async (tx) => {
+    await tx.$queryRaw`
+      SELECT "id"
+      FROM "ContentImport"
+      WHERE "id" = ${input.importId}
+      FOR UPDATE
+    `;
+
     const current = await tx.contentImport.findUnique({ where: { id: input.importId } });
     if (!current) {
       throw new ImportReviewApprovalPersistError('IMPORT_NOT_FOUND', 'Import not found.');
     }
     assertImportStatusAcceptsReviewApprovalUpdates(current.status);
-    const currentLoaded = loadImportReviewStateFromRow(current);
+
+    let currentLoaded: ReturnType<typeof loadImportReviewStateFromRow>;
+    try {
+      currentLoaded = loadImportReviewStateFromRow(current);
+    } catch (e) {
+      if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
+        throw new ImportReviewApprovalPersistError('REVIEW_APPROVALS_INVALID', e.message);
+      }
+      throw e;
+    }
     if (!currentLoaded) {
       throw new ImportReviewApprovalPersistError('REVIEW_MANIFEST_MISSING', 'Import has no review manifest.');
     }

--- a/src/server/imports/importCandidateReview/state.ts
+++ b/src/server/imports/importCandidateReview/state.ts
@@ -8,6 +8,16 @@ import type {
 } from '@/server/imports/candidateReviewManifest';
 import type { StoredReviewApprovalsEnvelope, StoredReviewManifestEnvelope } from '@/server/imports/importCandidateReview/storageSchema';
 
+export type ImportCandidateReconcileLoadErrorCode =
+  | 'REVIEW_MANIFEST_INVALID'
+  | 'REVIEW_APPROVALS_INVALID'
+  | 'REVIEW_APPROVALS_STALE';
+
+export type ImportCandidateReconcileLoadErrorDto = {
+  code: ImportCandidateReconcileLoadErrorCode;
+  message: string;
+};
+
 export type ImportCandidateReviewStateDto = {
   hasManifest: boolean;
   manifestRevision: string | null;
@@ -23,6 +33,7 @@ export type ImportCandidateReviewStateDto = {
   unresolvedBlockingCount: number;
   mergeReviewBlocked: boolean;
   advisoryOnly: boolean;
+  loadError: ImportCandidateReconcileLoadErrorDto | null;
 };
 
 export function buildImportCandidateReviewStateDto(input: {
@@ -54,6 +65,31 @@ export function buildImportCandidateReviewStateDto(input: {
         (manifest.accounting.patents.unresolvedAdvisoryDecisions > 0 ||
           manifest.accounting.research.unresolvedAdvisoryDecisions > 0),
     ),
+    loadError: null,
+  };
+}
+
+export function buildImportCandidateReviewCorruptedDto(input: {
+  code: ImportCandidateReconcileLoadErrorCode;
+  message: string;
+  hasManifest: boolean;
+}): ImportCandidateReviewStateDto {
+  return {
+    hasManifest: input.hasManifest,
+    manifestRevision: null,
+    sourceTextHash: null,
+    baseline: null,
+    generatedAt: null,
+    importSource: null,
+    decisions: [],
+    accounting: null,
+    analysisAccounting: null,
+    approvals: [],
+    approvalsUpdatedAt: null,
+    unresolvedBlockingCount: 1,
+    mergeReviewBlocked: true,
+    advisoryOnly: false,
+    loadError: { code: input.code, message: input.message },
   };
 }
 

--- a/src/server/imports/importCandidateReview/state.ts
+++ b/src/server/imports/importCandidateReview/state.ts
@@ -1,0 +1,62 @@
+import 'server-only';
+
+import type { Prisma } from '@prisma/client';
+
+import type {
+  CandidateReviewApproval,
+  CandidateReviewManifest,
+} from '@/server/imports/candidateReviewManifest';
+import type { StoredReviewApprovalsEnvelope, StoredReviewManifestEnvelope } from '@/server/imports/importCandidateReview/storageSchema';
+
+export type ImportCandidateReviewStateDto = {
+  hasManifest: boolean;
+  manifestRevision: string | null;
+  sourceTextHash: string | null;
+  baseline: CandidateReviewManifest['baseline'] | null;
+  generatedAt: string | null;
+  importSource: string | null;
+  decisions: CandidateReviewManifest['decisions'];
+  accounting: CandidateReviewManifest['accounting'] | null;
+  analysisAccounting: CandidateReviewManifest['analysisAccounting'] | null;
+  approvals: CandidateReviewApproval[];
+  approvalsUpdatedAt: string | null;
+  unresolvedBlockingCount: number;
+  mergeReviewBlocked: boolean;
+  advisoryOnly: boolean;
+};
+
+export function buildImportCandidateReviewStateDto(input: {
+  manifestEnvelope: StoredReviewManifestEnvelope | null;
+  manifest: CandidateReviewManifest | null;
+  approvalsEnvelope: StoredReviewApprovalsEnvelope | null;
+  approvals: readonly CandidateReviewApproval[];
+  unresolvedBlockingCount: number;
+}): ImportCandidateReviewStateDto {
+  const manifest = input.manifest;
+  const envelope = input.manifestEnvelope;
+  return {
+    hasManifest: Boolean(envelope && manifest),
+    manifestRevision: envelope?.manifestRevision ?? null,
+    sourceTextHash: envelope?.sourceTextHash ?? null,
+    baseline: manifest?.baseline ?? null,
+    generatedAt: manifest?.generatedAt ?? null,
+    importSource: manifest?.importSource ?? null,
+    decisions: manifest?.decisions ?? [],
+    accounting: manifest?.accounting ?? null,
+    analysisAccounting: manifest?.analysisAccounting ?? null,
+    approvals: [...input.approvals],
+    approvalsUpdatedAt: input.approvalsEnvelope?.updatedAt ?? null,
+    unresolvedBlockingCount: input.unresolvedBlockingCount,
+    mergeReviewBlocked: input.unresolvedBlockingCount > 0,
+    advisoryOnly: Boolean(
+      manifest &&
+        input.unresolvedBlockingCount === 0 &&
+        (manifest.accounting.patents.unresolvedAdvisoryDecisions > 0 ||
+          manifest.accounting.research.unresolvedAdvisoryDecisions > 0),
+    ),
+  };
+}
+
+export function reviewStateToJson(dto: ImportCandidateReviewStateDto): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(dto)) as Prisma.InputJsonValue;
+}

--- a/src/server/imports/importCandidateReview/storageSchema.ts
+++ b/src/server/imports/importCandidateReview/storageSchema.ts
@@ -1,0 +1,154 @@
+import { z } from 'zod';
+
+import type {
+  CandidateReviewApproval,
+  CandidateReviewManifest,
+} from '@/server/imports/candidateReviewManifest';
+import { computeImportReviewManifestRevision } from '@/server/imports/importCandidateReview/revision';
+
+export const IMPORT_REVIEW_STORAGE_VERSION = 1 as const;
+
+const reviewBaselineRefSchema = z.object({
+  sourceType: z.enum(['published', 'working_draft', 'canonical']),
+  versionId: z.string().nullable().optional(),
+  publishSequence: z.number().nullable().optional(),
+  label: z.string().nullable().optional(),
+});
+
+const reviewDecisionSchema = z.object({
+  decisionId: z.string().min(1),
+  section: z.enum(['publications', 'awards', 'patents', 'research']),
+  candidateId: z.string().optional(),
+  existingId: z.string().optional(),
+  relatedExistingIds: z.array(z.string()).optional(),
+  action: z.enum(['add', 'update', 'remove-artifact', 'preserve-existing', 'manual-review']),
+  reason: z.string(),
+  confidence: z.enum(['high', 'medium', 'low']),
+  affectedCount: z.number().int().nonnegative().optional(),
+});
+
+const baselineSectionAccountingSchema = z.object({
+  matchedBaseline: z.number().int().nonnegative(),
+  supersededBaseline: z.number().int().nonnegative(),
+  unresolvedBaseline: z.number().int().nonnegative(),
+  preservedBaseline: z.number().int().nonnegative(),
+  removedBaseline: z.number().int().nonnegative(),
+  resolvedSkipped: z.number().int().nonnegative(),
+  wrongSectionArtifact: z.number().int().nonnegative(),
+  clusteredBaseline: z.number().int().nonnegative(),
+});
+
+const reconciledSectionAccountingSchema = z.object({
+  mode: z.literal('reconciled'),
+  candidateTotal: z.number().int().nonnegative(),
+  baselineTotal: z.number().int().nonnegative(),
+  matchedUpdated: z.number().int().nonnegative(),
+  candidateOnlyAdded: z.number().int().nonnegative(),
+  baselinePreserved: z.number().int().nonnegative(),
+  baselineRemovedArtifact: z.number().int().nonnegative(),
+  unresolvedManualReview: z.number().int().nonnegative(),
+  resolvedSkipped: z.number().int().nonnegative(),
+  finalTotalAfterApprovals: z.number().int().nonnegative(),
+  baseline: baselineSectionAccountingSchema,
+});
+
+const advisorySectionAccountingSchema = z.object({
+  mode: z.literal('advisory'),
+  candidateTotal: z.number().int().nonnegative(),
+  baselineTotal: z.number().int().nonnegative(),
+  unresolvedAdvisoryDecisions: z.number().int().nonnegative(),
+  affectedRecordCount: z.number().int().nonnegative(),
+});
+
+const candidateReviewManifestSchema = z.object({
+  generatedAt: z.string(),
+  importId: z.string().nullable().optional(),
+  importSource: z.string(),
+  baseline: reviewBaselineRefSchema,
+  decisions: z.array(reviewDecisionSchema),
+  analysisAccounting: z.object({
+    publications: reconciledSectionAccountingSchema,
+    awards: reconciledSectionAccountingSchema,
+  }),
+  accounting: z.object({
+    publications: reconciledSectionAccountingSchema,
+    awards: reconciledSectionAccountingSchema,
+    patents: advisorySectionAccountingSchema,
+    research: advisorySectionAccountingSchema,
+  }),
+});
+
+export const storedReviewManifestEnvelopeSchema = z.object({
+  storageVersion: z.literal(IMPORT_REVIEW_STORAGE_VERSION),
+  manifestRevision: z.string().min(8),
+  sourceTextHash: z.string().min(8),
+  manifest: candidateReviewManifestSchema,
+});
+
+export const candidateReviewApprovalSchema = z.object({
+  decisionId: z.string().min(1),
+  approvedAction: z.enum(['preserve-existing', 'approve-removal', 'skip']),
+  selectedExistingId: z.string().optional(),
+});
+
+export const storedReviewApprovalsEnvelopeSchema = z.object({
+  storageVersion: z.literal(IMPORT_REVIEW_STORAGE_VERSION),
+  manifestRevision: z.string().min(8),
+  updatedAt: z.string(),
+  approvals: z.array(candidateReviewApprovalSchema),
+});
+
+export type StoredReviewManifestEnvelope = z.infer<typeof storedReviewManifestEnvelopeSchema>;
+export type StoredReviewApprovalsEnvelope = z.infer<typeof storedReviewApprovalsEnvelopeSchema>;
+
+export function parseStoredReviewManifest(input: unknown): StoredReviewManifestEnvelope | null {
+  const parsed = storedReviewManifestEnvelopeSchema.safeParse(input);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseStoredReviewApprovals(input: unknown): StoredReviewApprovalsEnvelope | null {
+  const parsed = storedReviewApprovalsEnvelopeSchema.safeParse(input);
+  return parsed.success ? parsed.data : null;
+}
+
+export function assertStoredManifestMatchesRevision(
+  envelope: StoredReviewManifestEnvelope,
+): CandidateReviewManifest {
+  const manifest = envelope.manifest as CandidateReviewManifest;
+  const expectedIds = manifest.decisions.map((d) => d.decisionId).sort();
+  const revisionIds = [...expectedIds];
+  const computed = computeImportReviewManifestRevision({
+    sourceTextHash: envelope.sourceTextHash,
+    decisionIds: revisionIds,
+  });
+  if (computed !== envelope.manifestRevision) {
+    throw new Error('Stored review manifest revision does not match content.');
+  }
+  return manifest;
+}
+
+export function toStoredManifestEnvelope(input: {
+  manifest: CandidateReviewManifest;
+  sourceTextHash: string;
+  manifestRevision: string;
+}): StoredReviewManifestEnvelope {
+  return {
+    storageVersion: IMPORT_REVIEW_STORAGE_VERSION,
+    manifestRevision: input.manifestRevision,
+    sourceTextHash: input.sourceTextHash,
+    manifest: input.manifest,
+  };
+}
+
+export function toStoredApprovalsEnvelope(input: {
+  manifestRevision: string;
+  approvals: readonly CandidateReviewApproval[];
+  updatedAt?: string;
+}): StoredReviewApprovalsEnvelope {
+  return {
+    storageVersion: IMPORT_REVIEW_STORAGE_VERSION,
+    manifestRevision: input.manifestRevision,
+    updatedAt: input.updatedAt ?? new Date().toISOString(),
+    approvals: [...input.approvals],
+  };
+}

--- a/src/server/imports/importCandidateReview/storageSchema.ts
+++ b/src/server/imports/importCandidateReview/storageSchema.ts
@@ -60,23 +60,38 @@ const advisorySectionAccountingSchema = z.object({
   affectedRecordCount: z.number().int().nonnegative(),
 });
 
-const candidateReviewManifestSchema = z.object({
-  generatedAt: z.string(),
-  importId: z.string().nullable().optional(),
-  importSource: z.string(),
-  baseline: reviewBaselineRefSchema,
-  decisions: z.array(reviewDecisionSchema),
-  analysisAccounting: z.object({
-    publications: reconciledSectionAccountingSchema,
-    awards: reconciledSectionAccountingSchema,
-  }),
-  accounting: z.object({
-    publications: reconciledSectionAccountingSchema,
-    awards: reconciledSectionAccountingSchema,
-    patents: advisorySectionAccountingSchema,
-    research: advisorySectionAccountingSchema,
-  }),
-});
+const candidateReviewManifestSchema = z
+  .object({
+    generatedAt: z.string(),
+    importId: z.string().nullable().optional(),
+    importSource: z.string(),
+    baseline: reviewBaselineRefSchema,
+    decisions: z.array(reviewDecisionSchema),
+    analysisAccounting: z.object({
+      publications: reconciledSectionAccountingSchema,
+      awards: reconciledSectionAccountingSchema,
+    }),
+    accounting: z.object({
+      publications: reconciledSectionAccountingSchema,
+      awards: reconciledSectionAccountingSchema,
+      patents: advisorySectionAccountingSchema,
+      research: advisorySectionAccountingSchema,
+    }),
+  })
+  .superRefine((value, ctx) => {
+    const seen = new Set<string>();
+    value.decisions.forEach((d, idx) => {
+      if (seen.has(d.decisionId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['decisions', idx, 'decisionId'],
+          message: 'decisionId must be unique within a manifest.',
+        });
+        return;
+      }
+      seen.add(d.decisionId);
+    });
+  });
 
 export const storedReviewManifestEnvelopeSchema = z.object({
   storageVersion: z.literal(IMPORT_REVIEW_STORAGE_VERSION),

--- a/src/server/imports/mergeImportToDraft.ts
+++ b/src/server/imports/mergeImportToDraft.ts
@@ -12,8 +12,17 @@ import {
 } from '@/server/content/contentWorkflowCore';
 import { prisma } from '@/server/db/prisma';
 import { buildImportMergeSafetyReport } from '@/server/imports/buildImportMergeSafetyReport';
-import { getDetailsFromCandidatePayload } from '@/server/imports/candidatePayload/schema';
+import { getDetailsFromCandidatePayload, parseImportCandidatePayload } from '@/server/imports/candidatePayload/schema';
 import { mergeCvDetailsIntoSiteContent } from '@/server/imports/detailsToSiteContentMerge';
+import {
+  ImportReviewReconcileError,
+  loadImportReviewStateFromRow,
+  reconcileCandidateForMerge,
+  verifyReviewManifestSourceHash,
+} from '@/server/imports/importCandidateReview/reconcile';
+import {
+  ensureImportReviewManifest,
+} from '@/server/imports/importCandidateReview/service';
 import { freezeKeysFromSafetyReport } from '@/server/imports/importMergeSectionSafety';
 import { type ImportReviewProvenance } from '@/server/imports/importReviewStructured';
 import { getContentImportDetail, updateImportStatus } from '@/server/imports/repository';
@@ -29,7 +38,11 @@ export class ImportMergeError extends Error {
       | 'NO_CANDIDATE'
       | 'INVALID_CANDIDATE'
       | 'MERGE_VALIDATION_FAILED'
-      | 'MERGE_ACK_REQUIRED',
+      | 'MERGE_ACK_REQUIRED'
+      | 'REVIEW_BLOCKED'
+      | 'REVIEW_MANIFEST_MISSING'
+      | 'REVIEW_MANIFEST_STALE'
+      | 'REVIEW_APPROVALS_STALE',
     message: string,
   ) {
     super(message);
@@ -69,6 +82,9 @@ export async function mergeImportCandidateToWorkingDraft(input: {
   mergeMode?: 'safe_update' | 'full_replace';
   /** Required when `mergeMode` is `full_replace` and the import has any non-safe section. */
   acknowledgeHighRisk?: boolean;
+  /** Required when unresolved publication/award reconciliation decisions remain. */
+  acknowledgeUnresolvedReview?: boolean;
+  unresolvedReviewReason?: string | null;
   changeSummary?: string | null;
 }): Promise<MergeImportCandidateResult> {
   const quick = await getContentImportDetail(input.importId);
@@ -86,7 +102,7 @@ export async function mergeImportCandidateToWorkingDraft(input: {
     // Draft was discarded (or replaced by a different import) — fall through to re-merge.
   }
 
-  const { importRow, details } = await loadDetailsFromImportRow(quick);
+  const { importRow, details: rawDetails } = await loadDetailsFromImportRow(quick);
   const baselineParsed = validateSiteContent(SITE_CONTENT_RAW);
   if (!baselineParsed.success) {
     throw new ImportMergeError('MERGE_VALIDATION_FAILED', 'Canonical baseline failed validation.');
@@ -98,6 +114,81 @@ export async function mergeImportCandidateToWorkingDraft(input: {
   }
   const baselineData = basePayload.data;
 
+  const manifestEnvelope = await ensureImportReviewManifest(input.importId);
+  const reviewRow = await getContentImportDetail(input.importId);
+  const loadedReview = reviewRow
+    ? loadImportReviewStateFromRow({
+        reviewManifest: reviewRow.reviewManifest,
+        reviewApprovals: reviewRow.reviewApprovals,
+        candidatePayload: reviewRow.candidatePayload,
+      })
+    : null;
+  if (!loadedReview) {
+    throw new ImportMergeError('REVIEW_MANIFEST_MISSING', 'Import has no reconciliation review manifest.');
+  }
+  const envelopePayload = parseImportCandidatePayload(importRow.candidatePayload);
+  if (envelopePayload) {
+    try {
+      verifyReviewManifestSourceHash(manifestEnvelope, envelopePayload.sourceTextHash);
+    } catch (e) {
+      if (e instanceof ImportReviewReconcileError) {
+        throw new ImportMergeError('REVIEW_MANIFEST_STALE', e.message);
+      }
+      throw e;
+    }
+  }
+
+  let reconciledDetails = rawDetails;
+  let reconciledAccounting: Prisma.InputJsonValue | null = null;
+  let unresolvedBlockingCount = 0;
+  try {
+    const reconciled = await reconcileCandidateForMerge({
+      candidate: rawDetails,
+      baseline: baselineData,
+      manifestEnvelope: loadedReview.manifestEnvelope,
+      manifest: loadedReview.manifestEnvelope.manifest,
+      approvals: loadedReview.approvals,
+      acknowledgeUnresolvedReview: input.acknowledgeUnresolvedReview,
+      unresolvedReviewReason: input.unresolvedReviewReason,
+    });
+    reconciledDetails = reconciled.details;
+    reconciledAccounting = JSON.parse(JSON.stringify(reconciled.manifest.accounting)) as Prisma.InputJsonValue;
+    unresolvedBlockingCount = reconciled.unresolvedBlockingCount;
+  } catch (e) {
+    if (e instanceof ImportReviewReconcileError) {
+      if (e.code === 'REVIEW_BLOCKED') {
+        throw new ImportMergeError('REVIEW_BLOCKED', e.message);
+      }
+      if (e.code === 'REVIEW_MANIFEST_STALE' || e.code === 'REVIEW_APPROVALS_STALE') {
+        throw new ImportMergeError(e.code, e.message);
+      }
+    }
+    throw e;
+  }
+
+  if (
+    input.acknowledgeUnresolvedReview &&
+    unresolvedBlockingCount > 0 &&
+    !input.unresolvedReviewReason?.trim()
+  ) {
+    throw new ImportMergeError(
+      'MERGE_ACK_REQUIRED',
+      'Unresolved reconciliation override requires unresolvedReviewReason.',
+    );
+  }
+
+  if (input.acknowledgeUnresolvedReview && unresolvedBlockingCount > 0) {
+    await recordContentEvent({
+      eventType: 'SYSTEM_NOTE',
+      payload: {
+        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+        importId: input.importId,
+        unresolvedBlockingCount,
+        reason: input.unresolvedReviewReason?.trim() ?? null,
+      },
+    });
+  }
+
   const provenance: ImportReviewProvenance = {
     importId: importRow.id,
     originalFileName: importRow.uploadedFile.originalName,
@@ -106,7 +197,7 @@ export async function mergeImportCandidateToWorkingDraft(input: {
   };
 
   const { mergeSafety: safety } = buildImportMergeSafetyReport({
-    details,
+    details: reconciledDetails,
     mergeBaseline: baselineData,
     candidatePayload: importRow.candidatePayload,
     provenance,
@@ -122,8 +213,10 @@ export async function mergeImportCandidateToWorkingDraft(input: {
 
   const merged =
     mergeMode === 'full_replace'
-      ? mergeCvDetailsIntoSiteContent(details, baselineData)
-      : mergeCvDetailsIntoSiteContent(details, baselineData, { freeze: freezeKeysFromSafetyReport(safety) });
+      ? mergeCvDetailsIntoSiteContent(reconciledDetails, baselineData)
+      : mergeCvDetailsIntoSiteContent(reconciledDetails, baselineData, {
+          freeze: freezeKeysFromSafetyReport(safety),
+        });
 
   const validated = validateSiteContent(merged);
   if (!validated.success) {
@@ -154,12 +247,26 @@ export async function mergeImportCandidateToWorkingDraft(input: {
     await recordContentEvent({
       eventType: 'WORKING_DRAFT_CREATED',
       versionId: row.id,
-      payload: { importId: input.importId, source: 'import_candidate' },
+      payload: {
+        importId: input.importId,
+        source: 'import_candidate',
+        reconciledAccounting,
+        unresolvedBlockingCount,
+        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+      },
     });
     await recordContentEvent({
       eventType: 'SYSTEM_NOTE',
       versionId: row.id,
-      payload: { kind: 'IMPORT_MERGED_TO_WORKING_DRAFT', importId: input.importId, action: 'create' },
+      payload: {
+        kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+        importId: input.importId,
+        action: 'create',
+        reconciledAccounting,
+        unresolvedBlockingCount,
+        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+        unresolvedReviewReason: input.unresolvedReviewReason ?? null,
+      },
     });
     await updateImportStatus(input.importId, 'MERGED');
     return { version: row, alreadyMerged: false };
@@ -179,12 +286,26 @@ export async function mergeImportCandidateToWorkingDraft(input: {
   await recordContentEvent({
     eventType: 'WORKING_DRAFT_UPDATED',
     versionId: row.id,
-    payload: { importId: input.importId, source: 'import_candidate_replace' },
+    payload: {
+      importId: input.importId,
+      source: 'import_candidate_replace',
+      reconciledAccounting,
+      unresolvedBlockingCount,
+      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+    },
   });
   await recordContentEvent({
     eventType: 'SYSTEM_NOTE',
     versionId: row.id,
-    payload: { kind: 'IMPORT_MERGED_TO_WORKING_DRAFT', importId: input.importId, action: 'replace' },
+    payload: {
+      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+      importId: input.importId,
+      action: 'replace',
+      reconciledAccounting,
+      unresolvedBlockingCount,
+      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+      unresolvedReviewReason: input.unresolvedReviewReason ?? null,
+    },
   });
   await updateImportStatus(input.importId, 'MERGED');
   return { version: row, alreadyMerged: false };

--- a/src/server/imports/mergeImportToDraft.ts
+++ b/src/server/imports/mergeImportToDraft.ts
@@ -42,7 +42,8 @@ export class ImportMergeError extends Error {
       | 'REVIEW_BLOCKED'
       | 'REVIEW_MANIFEST_MISSING'
       | 'REVIEW_MANIFEST_STALE'
-      | 'REVIEW_APPROVALS_STALE',
+      | 'REVIEW_APPROVALS_STALE'
+      | 'REVIEW_APPROVALS_INVALID',
     message: string,
   ) {
     super(message);
@@ -70,6 +71,50 @@ export type MergeImportCandidateResult = {
   version: ContentVersion;
   alreadyMerged: boolean;
 };
+
+async function recordSuccessfulMergeEvents(input: {
+  versionId: string;
+  importId: string;
+  action: 'create' | 'replace';
+  draftEventType: 'WORKING_DRAFT_CREATED' | 'WORKING_DRAFT_UPDATED';
+  draftEventPayload: Prisma.InputJsonValue;
+  reconciledAccounting: Prisma.InputJsonValue | null;
+  unresolvedBlockingCount: number;
+  acknowledgedUnresolvedReview: boolean;
+  normalizedUnresolvedReviewReason: string | null;
+}): Promise<void> {
+  await recordContentEvent({
+    eventType: input.draftEventType,
+    versionId: input.versionId,
+    payload: input.draftEventPayload,
+  });
+  await recordContentEvent({
+    eventType: 'SYSTEM_NOTE',
+    versionId: input.versionId,
+    payload: {
+      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
+      importId: input.importId,
+      action: input.action,
+      reconciledAccounting: input.reconciledAccounting,
+      unresolvedBlockingCount: input.unresolvedBlockingCount,
+      acknowledgedUnresolvedReview: input.acknowledgedUnresolvedReview,
+      unresolvedReviewReason: input.normalizedUnresolvedReviewReason,
+    },
+  });
+  if (input.acknowledgedUnresolvedReview) {
+    await recordContentEvent({
+      eventType: 'SYSTEM_NOTE',
+      versionId: input.versionId,
+      payload: {
+        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+        importId: input.importId,
+        versionId: input.versionId,
+        unresolvedBlockingCount: input.unresolvedBlockingCount,
+        reason: input.normalizedUnresolvedReviewReason,
+      },
+    });
+  }
+}
 
 /**
  * Creates a working draft from the import candidate, or replaces the existing draft payload.
@@ -115,14 +160,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
   const baselineData = basePayload.data;
 
   const manifestEnvelope = await ensureImportReviewManifest(input.importId);
+  // Reload after ensureImportReviewManifest — it may have lazily generated and persisted a manifest.
   const reviewRow = await getContentImportDetail(input.importId);
-  const loadedReview = reviewRow
-    ? loadImportReviewStateFromRow({
+  let loadedReview: ReturnType<typeof loadImportReviewStateFromRow> = null;
+  if (reviewRow) {
+    try {
+      loadedReview = loadImportReviewStateFromRow({
         reviewManifest: reviewRow.reviewManifest,
         reviewApprovals: reviewRow.reviewApprovals,
-        candidatePayload: reviewRow.candidatePayload,
-      })
-    : null;
+      });
+    } catch (e) {
+      if (e instanceof ImportReviewReconcileError && e.code === 'REVIEW_APPROVALS_INVALID') {
+        throw new ImportMergeError('REVIEW_APPROVALS_INVALID', e.message);
+      }
+      throw e;
+    }
+  }
   if (!loadedReview) {
     throw new ImportMergeError('REVIEW_MANIFEST_MISSING', 'Import has no reconciliation review manifest.');
   }
@@ -166,27 +219,17 @@ export async function mergeImportCandidateToWorkingDraft(input: {
     throw e;
   }
 
-  if (
-    input.acknowledgeUnresolvedReview &&
-    unresolvedBlockingCount > 0 &&
-    !input.unresolvedReviewReason?.trim()
-  ) {
+  const acknowledgedUnresolvedReview =
+    Boolean(input.acknowledgeUnresolvedReview) && unresolvedBlockingCount > 0;
+  const normalizedUnresolvedReviewReason = acknowledgedUnresolvedReview
+    ? (input.unresolvedReviewReason?.trim() ?? '')
+    : '';
+
+  if (acknowledgedUnresolvedReview && normalizedUnresolvedReviewReason.length < 8) {
     throw new ImportMergeError(
       'MERGE_ACK_REQUIRED',
-      'Unresolved reconciliation override requires unresolvedReviewReason.',
+      'Unresolved reconciliation override requires unresolvedReviewReason of at least 8 characters.',
     );
-  }
-
-  if (input.acknowledgeUnresolvedReview && unresolvedBlockingCount > 0) {
-    await recordContentEvent({
-      eventType: 'SYSTEM_NOTE',
-      payload: {
-        kind: 'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
-        importId: input.importId,
-        unresolvedBlockingCount,
-        reason: input.unresolvedReviewReason?.trim() ?? null,
-      },
-    });
   }
 
   const provenance: ImportReviewProvenance = {
@@ -244,29 +287,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
         createdBy: null,
       },
     });
-    await recordContentEvent({
-      eventType: 'WORKING_DRAFT_CREATED',
+    await recordSuccessfulMergeEvents({
       versionId: row.id,
-      payload: {
+      importId: input.importId,
+      action: 'create',
+      draftEventType: 'WORKING_DRAFT_CREATED',
+      draftEventPayload: {
         importId: input.importId,
         source: 'import_candidate',
         reconciledAccounting,
         unresolvedBlockingCount,
-        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+        acknowledgedUnresolvedReview,
       },
-    });
-    await recordContentEvent({
-      eventType: 'SYSTEM_NOTE',
-      versionId: row.id,
-      payload: {
-        kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
-        importId: input.importId,
-        action: 'create',
-        reconciledAccounting,
-        unresolvedBlockingCount,
-        acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
-        unresolvedReviewReason: input.unresolvedReviewReason ?? null,
-      },
+      reconciledAccounting,
+      unresolvedBlockingCount,
+      acknowledgedUnresolvedReview,
+      normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
     });
     await updateImportStatus(input.importId, 'MERGED');
     return { version: row, alreadyMerged: false };
@@ -283,29 +319,22 @@ export async function mergeImportCandidateToWorkingDraft(input: {
       changeSummary: input.changeSummary ?? working.changeSummary,
     },
   });
-  await recordContentEvent({
-    eventType: 'WORKING_DRAFT_UPDATED',
+  await recordSuccessfulMergeEvents({
     versionId: row.id,
-    payload: {
+    importId: input.importId,
+    action: 'replace',
+    draftEventType: 'WORKING_DRAFT_UPDATED',
+    draftEventPayload: {
       importId: input.importId,
       source: 'import_candidate_replace',
       reconciledAccounting,
       unresolvedBlockingCount,
-      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
+      acknowledgedUnresolvedReview,
     },
-  });
-  await recordContentEvent({
-    eventType: 'SYSTEM_NOTE',
-    versionId: row.id,
-    payload: {
-      kind: 'IMPORT_MERGED_TO_WORKING_DRAFT',
-      importId: input.importId,
-      action: 'replace',
-      reconciledAccounting,
-      unresolvedBlockingCount,
-      acknowledgedUnresolvedReview: Boolean(input.acknowledgeUnresolvedReview),
-      unresolvedReviewReason: input.unresolvedReviewReason ?? null,
-    },
+    reconciledAccounting,
+    unresolvedBlockingCount,
+    acknowledgedUnresolvedReview,
+    normalizedUnresolvedReviewReason: normalizedUnresolvedReviewReason || null,
   });
   await updateImportStatus(input.importId, 'MERGED');
   return { version: row, alreadyMerged: false };

--- a/src/server/imports/runDocxImportParseJob.ts
+++ b/src/server/imports/runDocxImportParseJob.ts
@@ -13,6 +13,7 @@ import {
   resolveImportStatusAfterParse,
   zodIssuesToImportItems,
 } from '@/server/imports/docxImportArtifacts';
+import { generateAndPersistImportReviewManifest } from '@/server/imports/importCandidateReview/service';
 import {
   persistImportParseFailure,
   persistImportParseOutcome,
@@ -128,6 +129,19 @@ export async function runDocxImportParseJob(input: {
       parserVersion: PARSER_VERSION,
     });
     persistMs = Date.now() - persistStart;
+
+    try {
+      await generateAndPersistImportReviewManifest(input.importId);
+    } catch (reviewErr) {
+      const reviewMessage = reviewErr instanceof Error ? reviewErr.message : String(reviewErr);
+      console.warn(
+        JSON.stringify({
+          event: 'import_review_manifest_failed',
+          importId: input.importId,
+          message: reviewMessage,
+        }),
+      );
+    }
 
     logParseEvent({
       importId: input.importId,

--- a/src/server/imports/serialize.ts
+++ b/src/server/imports/serialize.ts
@@ -4,8 +4,16 @@ import type { ContentImport, UploadedFile } from '@prisma/client';
 
 import { getDetailsFromCandidatePayload, parseImportCandidatePayload } from '@/server/imports/candidatePayload/schema';
 import { countUnresolvedBlockingDecisions } from '@/server/imports/importCandidateReview/gate';
-import { loadImportReviewStateFromRow } from '@/server/imports/importCandidateReview/reconcile';
-import { buildImportCandidateReviewStateDto } from '@/server/imports/importCandidateReview/state';
+import {
+  ImportReviewReconcileError,
+  loadImportReviewStateFromRow,
+  verifyReviewApprovalsRevision,
+} from '@/server/imports/importCandidateReview/reconcile';
+import {
+  buildImportCandidateReviewCorruptedDto,
+  buildImportCandidateReviewStateDto,
+  type ImportCandidateReconcileLoadErrorCode,
+} from '@/server/imports/importCandidateReview/state';
 import {
   importWarningItemSchema,
   type ImportCandidateReconcileReviewDto,
@@ -138,23 +146,63 @@ export function buildImportCandidateSummary(payload: unknown): ImportCandidateSu
   };
 }
 
+const RECONCILE_ADMIN_LOAD_ERROR_CODES = new Set<ImportReviewReconcileError['code']>([
+  'REVIEW_MANIFEST_INVALID',
+  'REVIEW_APPROVALS_INVALID',
+  'REVIEW_APPROVALS_STALE',
+]);
+
+function adminFacingReconcileLoadMessage(code: ImportCandidateReconcileLoadErrorCode): string {
+  switch (code) {
+    case 'REVIEW_MANIFEST_INVALID':
+      return 'Stored reconciliation manifest is invalid.';
+    case 'REVIEW_APPROVALS_INVALID':
+      return 'Stored reconciliation approvals are invalid.';
+    case 'REVIEW_APPROVALS_STALE':
+      return 'Stored reconciliation approvals do not match the current manifest revision.';
+  }
+}
+
 export function buildImportCandidateReconcileReview(
   row: Pick<ContentImport, 'reviewManifest' | 'reviewApprovals'>,
 ): ImportCandidateReconcileReviewDto | null {
-  const loaded = loadImportReviewStateFromRow({
-    reviewManifest: row.reviewManifest,
-    reviewApprovals: row.reviewApprovals,
-  });
-  if (!loaded) {
+  const hasStoredManifest = row.reviewManifest !== null && row.reviewManifest !== undefined;
+  if (!hasStoredManifest) {
     return null;
   }
-  return buildImportCandidateReviewStateDto({
-    manifestEnvelope: loaded.manifestEnvelope,
-    manifest: loaded.manifest,
-    approvalsEnvelope: loaded.approvalsEnvelope,
-    approvals: loaded.approvals,
-    unresolvedBlockingCount: countUnresolvedBlockingDecisions(loaded.manifest),
-  });
+
+  try {
+    const loaded = loadImportReviewStateFromRow({
+      reviewManifest: row.reviewManifest,
+      reviewApprovals: row.reviewApprovals,
+    });
+    if (!loaded) {
+      return buildImportCandidateReviewCorruptedDto({
+        code: 'REVIEW_MANIFEST_INVALID',
+        message: adminFacingReconcileLoadMessage('REVIEW_MANIFEST_INVALID'),
+        hasManifest: true,
+      });
+    }
+    if (loaded.approvalsEnvelope) {
+      verifyReviewApprovalsRevision(loaded.manifestEnvelope, loaded.approvalsEnvelope);
+    }
+    return buildImportCandidateReviewStateDto({
+      manifestEnvelope: loaded.manifestEnvelope,
+      manifest: loaded.manifest,
+      approvalsEnvelope: loaded.approvalsEnvelope,
+      approvals: loaded.approvals,
+      unresolvedBlockingCount: countUnresolvedBlockingDecisions(loaded.manifest),
+    });
+  } catch (e) {
+    if (e instanceof ImportReviewReconcileError && RECONCILE_ADMIN_LOAD_ERROR_CODES.has(e.code)) {
+      return buildImportCandidateReviewCorruptedDto({
+        code: e.code as ImportCandidateReconcileLoadErrorCode,
+        message: adminFacingReconcileLoadMessage(e.code as ImportCandidateReconcileLoadErrorCode),
+        hasManifest: true,
+      });
+    }
+    throw e;
+  }
 }
 
 export function toImportDetail(row: ImportWithFileAndVersions): ImportDetailDto {

--- a/src/server/imports/serialize.ts
+++ b/src/server/imports/serialize.ts
@@ -3,8 +3,12 @@ import 'server-only';
 import type { ContentImport, UploadedFile } from '@prisma/client';
 
 import { getDetailsFromCandidatePayload, parseImportCandidatePayload } from '@/server/imports/candidatePayload/schema';
+import { countUnresolvedBlockingDecisions } from '@/server/imports/importCandidateReview/gate';
+import { loadImportReviewStateFromRow } from '@/server/imports/importCandidateReview/reconcile';
+import { buildImportCandidateReviewStateDto } from '@/server/imports/importCandidateReview/state';
 import {
   importWarningItemSchema,
+  type ImportCandidateReconcileReviewDto,
   type ImportCandidateReviewMetadataDto,
   type ImportCandidateSummaryDto,
   type ImportDetailDto,
@@ -134,6 +138,26 @@ export function buildImportCandidateSummary(payload: unknown): ImportCandidateSu
   };
 }
 
+export function buildImportCandidateReconcileReview(
+  row: Pick<ContentImport, 'reviewManifest' | 'reviewApprovals'>,
+): ImportCandidateReconcileReviewDto | null {
+  const loaded = loadImportReviewStateFromRow({
+    reviewManifest: row.reviewManifest,
+    reviewApprovals: row.reviewApprovals,
+    candidatePayload: null,
+  });
+  if (!loaded) {
+    return null;
+  }
+  return buildImportCandidateReviewStateDto({
+    manifestEnvelope: loaded.manifestEnvelope,
+    manifest: loaded.manifest,
+    approvalsEnvelope: loaded.approvalsEnvelope,
+    approvals: loaded.approvals,
+    unresolvedBlockingCount: countUnresolvedBlockingDecisions(loaded.manifest),
+  });
+}
+
 export function toImportDetail(row: ImportWithFileAndVersions): ImportDetailDto {
   const summary = toImportSummary(row);
   const detailsOnly = getDetailsFromCandidatePayload(row.candidatePayload);
@@ -148,6 +172,7 @@ export function toImportDetail(row: ImportWithFileAndVersions): ImportDetailDto 
     candidatePayload: (detailsOnly ?? row.candidatePayload) as ImportDetailDto['candidatePayload'],
     candidateSummary: buildImportCandidateSummary(row.candidatePayload),
     candidateReview: buildImportCandidateReviewMetadata(row.candidatePayload),
+    candidateReconcileReview: buildImportCandidateReconcileReview(row),
     warnings: parseImportWarnings(row.warnings),
     linkedVersionIds: row.versions.map((v: { id: string }) => v.id),
   };

--- a/src/server/imports/serialize.ts
+++ b/src/server/imports/serialize.ts
@@ -144,7 +144,6 @@ export function buildImportCandidateReconcileReview(
   const loaded = loadImportReviewStateFromRow({
     reviewManifest: row.reviewManifest,
     reviewApprovals: row.reviewApprovals,
-    candidatePayload: null,
   });
   if (!loaded) {
     return null;

--- a/src/server/imports/types.ts
+++ b/src/server/imports/types.ts
@@ -132,6 +132,10 @@ export type ImportCandidateReconcileReviewDto = {
   unresolvedBlockingCount: number;
   mergeReviewBlocked: boolean;
   advisoryOnly: boolean;
+  loadError: {
+    code: 'REVIEW_MANIFEST_INVALID' | 'REVIEW_APPROVALS_INVALID' | 'REVIEW_APPROVALS_STALE';
+    message: string;
+  } | null;
 };
 
 export type ImportDetailDto = ImportSummaryDto & {

--- a/src/server/imports/types.ts
+++ b/src/server/imports/types.ts
@@ -98,6 +98,42 @@ export type ImportCandidateReviewMetadataDto = {
   parserWarnings: ImportParserWarningItemDto[];
 };
 
+export type ImportCandidateReconcileReviewDto = {
+  hasManifest: boolean;
+  manifestRevision: string | null;
+  sourceTextHash: string | null;
+  baseline: {
+    sourceType: string;
+    versionId?: string | null;
+    publishSequence?: number | null;
+    label?: string | null;
+  } | null;
+  generatedAt: string | null;
+  importSource: string | null;
+  decisions: Array<{
+    decisionId: string;
+    section: string;
+    candidateId?: string;
+    existingId?: string;
+    relatedExistingIds?: string[];
+    action: string;
+    reason: string;
+    confidence: string;
+    affectedCount?: number;
+  }>;
+  accounting: Prisma.JsonValue | null;
+  analysisAccounting: Prisma.JsonValue | null;
+  approvals: Array<{
+    decisionId: string;
+    approvedAction: string;
+    selectedExistingId?: string;
+  }>;
+  approvalsUpdatedAt: string | null;
+  unresolvedBlockingCount: number;
+  mergeReviewBlocked: boolean;
+  advisoryOnly: boolean;
+};
+
 export type ImportDetailDto = ImportSummaryDto & {
   mimeType: string;
   sizeBytes: number;
@@ -109,6 +145,8 @@ export type ImportDetailDto = ImportSummaryDto & {
   candidateSummary: ImportCandidateSummaryDto | null;
   /** Present when `candidatePayload` is a parsed envelope (`schemaVersion` === 2). */
   candidateReview: ImportCandidateReviewMetadataDto | null;
+  /** Candidate-vs-baseline reconciliation manifest and approvals. */
+  candidateReconcileReview: ImportCandidateReconcileReviewDto | null;
   warnings: ImportWarningItem[];
   linkedVersionIds: string[];
 };

--- a/src/tests/imports/docxUploadImport.test.ts
+++ b/src/tests/imports/docxUploadImport.test.ts
@@ -99,8 +99,10 @@ describe('processDocxUploadWithImportPersistence', () => {
         warnings: null,
         rawPreviewPath: null,
         rawExtract: null,
-        candidatePayload: null,
-        createdAt: new Date(),
+      candidatePayload: null,
+      reviewManifest: null,
+      reviewApprovals: null,
+      createdAt: new Date(),
         updatedAt: new Date(),
       },
     });

--- a/src/tests/imports/importCandidateReconcilePanel.test.tsx
+++ b/src/tests/imports/importCandidateReconcilePanel.test.tsx
@@ -1,0 +1,103 @@
+/** @vitest-environment happy-dom */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ImportCandidateReconcilePanel } from '@/app/admin/imports/ImportCandidateReconcilePanel';
+import type { ImportCandidateReconcileReviewModel } from '@/app/admin/imports/importDetailTypes';
+
+const reconcile: ImportCandidateReconcileReviewModel = {
+  hasManifest: true,
+  manifestRevision: 'abcd1234abcd1234abcd1234abcd1234',
+  sourceTextHash: 'hash',
+  baseline: { sourceType: 'canonical', label: 'Canonical baseline' },
+  generatedAt: '2026-01-01T00:00:00.000Z',
+  importSource: 'cv.docx',
+  decisions: [
+    {
+      decisionId: 'publications:base-1::manual-review',
+      section: 'publications',
+      existingId: 'base-1',
+      action: 'manual-review',
+      reason: 'Baseline-only publication',
+      confidence: 'medium',
+    },
+    {
+      decisionId: 'awards:artifact-1::remove-artifact',
+      section: 'awards',
+      existingId: 'artifact-1',
+      action: 'remove-artifact',
+      reason: 'Professional Memberships row',
+      confidence: 'high',
+    },
+    {
+      decisionId: 'awards:cluster:dup-a+dup-b',
+      section: 'awards',
+      existingId: 'dup-a',
+      relatedExistingIds: ['dup-b'],
+      action: 'manual-review',
+      reason: 'Duplicate cluster',
+      confidence: 'medium',
+    },
+    {
+      decisionId: 'patents:status-unknown',
+      section: 'patents',
+      action: 'manual-review',
+      reason: 'Advisory patent status',
+      confidence: 'high',
+      affectedCount: 2,
+    },
+  ],
+  accounting: {
+    publications: { candidateTotal: 1, baselineTotal: 2, unresolvedManualReview: 1 },
+    awards: { candidateTotal: 0, baselineTotal: 3, unresolvedManualReview: 2 },
+  },
+  analysisAccounting: null,
+  approvals: [],
+  approvalsUpdatedAt: null,
+  unresolvedBlockingCount: 3,
+  mergeReviewBlocked: true,
+  advisoryOnly: false,
+};
+
+describe('ImportCandidateReconcilePanel', () => {
+  it('renders advisory section without approval controls', () => {
+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={vi.fn()} />);
+    expect(screen.getByText(/Advisory sections/i)).toBeTruthy();
+    expect(screen.getByText(/Informational only/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Preserve existing/i })).toBeTruthy();
+  });
+
+  it('does not offer preserve-existing for remove-artifact decisions', () => {
+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={vi.fn()} />);
+    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div');
+    expect(artifactCard?.textContent).toContain('Approve removal');
+    expect(artifactCard?.textContent).not.toContain('Preserve existing');
+  });
+
+  it('shows cluster preserve controls', () => {
+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={vi.fn()} />);
+    expect(screen.getByText(/Cluster members: dup-a, dup-b/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Preserve selected/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Remove entire cluster/i })).toBeTruthy();
+  });
+
+  it('submits approvals to API', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const onSaved = vi.fn();
+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={onSaved} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Approve removal/i })[0]!);
+    fireEvent.click(screen.getByRole('button', { name: /Save reconciliation approvals/i }));
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/admin/imports/imp-1/review-approvals',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/tests/imports/importCandidateReconcilePanel.test.tsx
+++ b/src/tests/imports/importCandidateReconcilePanel.test.tsx
@@ -58,6 +58,7 @@ const reconcile: ImportCandidateReconcileReviewModel = {
   unresolvedBlockingCount: 3,
   mergeReviewBlocked: true,
   advisoryOnly: false,
+  loadError: null,
 };
 
 describe('ImportCandidateReconcilePanel', () => {
@@ -107,6 +108,34 @@ describe('ImportCandidateReconcilePanel', () => {
     );
     const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div');
     expect(artifactCard?.textContent).toContain('saved');
+  });
+
+  it('renders blocking error card when stored reconciliation data is corrupted', () => {
+    const corrupted: ImportCandidateReconcileReviewModel = {
+      hasManifest: true,
+      manifestRevision: null,
+      sourceTextHash: null,
+      baseline: null,
+      generatedAt: null,
+      importSource: null,
+      decisions: [],
+      accounting: null,
+      analysisAccounting: null,
+      approvals: [],
+      approvalsUpdatedAt: null,
+      unresolvedBlockingCount: 1,
+      mergeReviewBlocked: true,
+      advisoryOnly: false,
+      loadError: {
+        code: 'REVIEW_APPROVALS_INVALID',
+        message: 'Stored reconciliation approvals are invalid.',
+      },
+    };
+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={corrupted} onSaved={vi.fn()} />);
+    expect(screen.getByText(/Stored reconciliation data is invalid/i)).toBeTruthy();
+    expect(screen.getByText(/Merge is blocked/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Save reconciliation approvals/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Approve removal/i })).toBeNull();
   });
 
   it('submits approvals to API', async () => {

--- a/src/tests/imports/importCandidateReconcilePanel.test.tsx
+++ b/src/tests/imports/importCandidateReconcilePanel.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment happy-dom */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ImportCandidateReconcilePanel } from '@/app/admin/imports/ImportCandidateReconcilePanel';
@@ -80,6 +80,33 @@ describe('ImportCandidateReconcilePanel', () => {
     expect(screen.getByText(/Cluster members: dup-a, dup-b/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /Preserve selected/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /Remove entire cluster/i })).toBeTruthy();
+  });
+
+  it('shows unsaved badge for local draft approval before save', () => {
+    render(<ImportCandidateReconcilePanel importId="imp-1" reconcile={reconcile} onSaved={vi.fn()} />);
+    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div')!;
+    expect(artifactCard.textContent).toContain('pending');
+    fireEvent.click(within(artifactCard).getByRole('button', { name: /Approve removal/i }));
+    expect(artifactCard.textContent).toContain('unsaved');
+    expect(within(artifactCard).getByText('unsaved')).toBeTruthy();
+  });
+
+  it('shows saved badge for server-persisted approval', () => {
+    const withSavedApproval: ImportCandidateReconcileReviewModel = {
+      ...reconcile,
+      approvals: [
+        {
+          decisionId: 'awards:artifact-1::remove-artifact',
+          approvedAction: 'approve-removal',
+        },
+      ],
+      unresolvedBlockingCount: 2,
+    };
+    render(
+      <ImportCandidateReconcilePanel importId="imp-1" reconcile={withSavedApproval} onSaved={vi.fn()} />,
+    );
+    const artifactCard = screen.getByText(/Professional Memberships row/i).closest('div');
+    expect(artifactCard?.textContent).toContain('saved');
   });
 
   it('submits approvals to API', async () => {

--- a/src/tests/imports/importCandidateReviewWorkflow.test.ts
+++ b/src/tests/imports/importCandidateReviewWorkflow.test.ts
@@ -39,13 +39,16 @@ import {
   generateImportReviewManifest,
   summarizeReviewManifestForAudit,
 } from '@/server/imports/importCandidateReview/generate';
+import { loadImportReviewStateFromRow } from '@/server/imports/importCandidateReview/reconcile';
 import { computeImportReviewManifestRevision } from '@/server/imports/importCandidateReview/revision';
 import {
   saveImportReviewApprovals,
+  importStatusAcceptsReviewApprovalUpdates,
 } from '@/server/imports/importCandidateReview/service';
 import {
   parseStoredReviewApprovals,
   parseStoredReviewManifest,
+  storedReviewManifestEnvelopeSchema,
   toStoredApprovalsEnvelope,
 } from '@/server/imports/importCandidateReview/storageSchema';
 import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
@@ -94,8 +97,9 @@ describe('import candidate review storage', () => {
       candidate,
     });
     const decision = manifest.decisions.find((d) => d.action === 'manual-review');
+    expect(decision).toBeDefined();
     if (!decision) {
-      return;
+      throw new Error('Expected at least one manual-review decision for this fixture.');
     }
     vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
       id: IMPORT_ID,
@@ -126,8 +130,9 @@ describe('import candidate review storage', () => {
     const decision = manifest.decisions.find(
       (d) => d.section === 'publications' && d.action === 'manual-review',
     );
+    expect(decision).toBeDefined();
     if (!decision) {
-      return;
+      throw new Error('Expected a publications manual-review decision for this fixture.');
     }
     const approvalsEnvelope = toStoredApprovalsEnvelope({
       manifestRevision: envelope.manifestRevision,
@@ -244,6 +249,133 @@ describe('import candidate review storage', () => {
       approvals: [{ decisionId: 'a:1', approvedAction: 'skip' }],
     });
     expect(parseStoredReviewApprovals(approvals)?.manifestRevision).toBe(revisionA);
+  });
+
+  it('rejects duplicate decisionId values in stored manifest envelope', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    expect(manifest.decisions.length).toBeGreaterThan(0);
+    const duplicateDecision = { ...manifest.decisions[0]! };
+    const malformed = {
+      ...envelope,
+      manifest: {
+        ...manifest,
+        decisions: [...manifest.decisions, duplicateDecision],
+      },
+    };
+    expect(parseStoredReviewManifest(malformed)).toBeNull();
+  });
+
+  it('accepts unique decisionId values in stored manifest envelope', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    expect(storedReviewManifestEnvelopeSchema.safeParse(envelope).success).toBe(true);
+  });
+
+  it('fails closed when stored approvals are malformed', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    expect(() =>
+      loadImportReviewStateFromRow({
+        reviewManifest: envelope,
+        reviewApprovals: { not: 'valid' },
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'REVIEW_APPROVALS_INVALID' }));
+  });
+
+  it('rejects approval save when import status flips to finalized inside transaction', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const decision = manifest.decisions.find(
+      (d) => d.section === 'publications' && d.action === 'manual-review',
+    );
+    expect(decision).toBeDefined();
+    if (!decision) {
+      throw new Error('Expected a publications manual-review decision for this fixture.');
+    }
+
+    vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
+      id: IMPORT_ID,
+      status: 'PARSED',
+      candidatePayload: payload,
+      reviewManifest: envelope,
+      reviewApprovals: null,
+    } as never);
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
+      const tx = {
+        contentImport: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: IMPORT_ID,
+            status: 'MERGED',
+            candidatePayload: payload,
+            reviewManifest: envelope,
+            reviewApprovals: null,
+          }),
+          update: vi.fn(),
+        },
+      };
+      return fn(tx as never);
+    });
+
+    await expect(
+      saveImportReviewApprovals({
+        importId: IMPORT_ID,
+        manifestRevision: envelope.manifestRevision,
+        approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+      }),
+    ).rejects.toMatchObject({ code: 'IMPORT_FINALIZED' });
+  });
+
+  it('documents allowed import statuses for review approval updates', () => {
+    expect(importStatusAcceptsReviewApprovalUpdates('PARSED')).toBe(true);
+    expect(importStatusAcceptsReviewApprovalUpdates('NEEDS_REVIEW')).toBe(true);
+    expect(importStatusAcceptsReviewApprovalUpdates('MERGED')).toBe(false);
+    expect(importStatusAcceptsReviewApprovalUpdates('REJECTED')).toBe(false);
+    expect(importStatusAcceptsReviewApprovalUpdates('FAILED')).toBe(false);
+    expect(importStatusAcceptsReviewApprovalUpdates('UPLOADED')).toBe(false);
+  });
+
+  it('uses unambiguous revision serialization for unusual decision ids', () => {
+    const hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const revisionA = computeImportReviewManifestRevision({
+      sourceTextHash: hash,
+      decisionIds: ['id\nb', 'id'],
+    });
+    const revisionB = computeImportReviewManifestRevision({
+      sourceTextHash: hash,
+      decisionIds: ['id', 'id\nb'],
+    });
+    const revisionC = computeImportReviewManifestRevision({
+      sourceTextHash: hash,
+      decisionIds: ['id', 'idb'],
+    });
+    expect(revisionA).toBe(revisionB);
+    expect(revisionA).not.toBe(revisionC);
   });
 
   it('advisory patent decisions do not block merge accounting count', async () => {

--- a/src/tests/imports/importCandidateReviewWorkflow.test.ts
+++ b/src/tests/imports/importCandidateReviewWorkflow.test.ts
@@ -55,6 +55,35 @@ import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
 
 const IMPORT_ID = 'imp-review-workflow';
 
+function mockApprovalSaveTransaction(input: {
+  importId: string;
+  row: Record<string, unknown>;
+  onLocked?: () => void;
+}) {
+  const callOrder: string[] = [];
+  const queryRaw = vi.fn(async () => {
+    callOrder.push('lock');
+    input.onLocked?.();
+    return [{ id: input.importId }];
+  });
+  const findUnique = vi.fn(async () => {
+    callOrder.push('read');
+    return input.row;
+  });
+  const update = vi.fn(async () => {
+    callOrder.push('update');
+    return {};
+  });
+  vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
+    const tx = {
+      $queryRaw: queryRaw,
+      contentImport: { findUnique, update },
+    };
+    return fn(tx as never);
+  });
+  return { callOrder, queryRaw, findUnique, update };
+}
+
 function envelopeFromDetails(details = minimalImportDetails(), rawDocumentText = 'cv body text for hash') {
   return buildImportCandidatePayload({
     rawDocumentText,
@@ -164,6 +193,7 @@ describe('import candidate review storage', () => {
 
     vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
       const tx = {
+        $queryRaw: vi.fn().mockResolvedValue([{ id: IMPORT_ID }]),
         contentImport: {
           findUnique: vi.fn().mockResolvedValue({
             id: IMPORT_ID,
@@ -326,20 +356,15 @@ describe('import candidate review storage', () => {
       reviewApprovals: null,
     } as never);
 
-    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
-      const tx = {
-        contentImport: {
-          findUnique: vi.fn().mockResolvedValue({
-            id: IMPORT_ID,
-            status: 'MERGED',
-            candidatePayload: payload,
-            reviewManifest: envelope,
-            reviewApprovals: null,
-          }),
-          update: vi.fn(),
-        },
-      };
-      return fn(tx as never);
+    const { callOrder, update } = mockApprovalSaveTransaction({
+      importId: IMPORT_ID,
+      row: {
+        id: IMPORT_ID,
+        status: 'MERGED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: null,
+      },
     });
 
     await expect(
@@ -349,6 +374,128 @@ describe('import candidate review storage', () => {
         approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
       }),
     ).rejects.toMatchObject({ code: 'IMPORT_FINALIZED' });
+    expect(callOrder).toEqual(['lock', 'read']);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('locks the import row before reading and updating approvals', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const decision = manifest.decisions.find(
+      (d) => d.section === 'publications' && d.action === 'manual-review',
+    );
+    expect(decision).toBeDefined();
+    if (!decision) {
+      throw new Error('Expected a publications manual-review decision for this fixture.');
+    }
+
+    vi.mocked(prisma.contentImport.findUnique)
+      .mockResolvedValueOnce({
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: null,
+      } as never)
+      .mockResolvedValueOnce({
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: toStoredApprovalsEnvelope({
+          manifestRevision: envelope.manifestRevision,
+          approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+        }),
+      } as never)
+      .mockResolvedValueOnce({
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: toStoredApprovalsEnvelope({
+          manifestRevision: envelope.manifestRevision,
+          approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+        }),
+      } as never);
+
+    const { callOrder, queryRaw, findUnique, update } = mockApprovalSaveTransaction({
+      importId: IMPORT_ID,
+      row: {
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: null,
+      },
+    });
+
+    await saveImportReviewApprovals({
+      importId: IMPORT_ID,
+      manifestRevision: envelope.manifestRevision,
+      approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+    });
+
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['lock', 'read', 'update']);
+    expect(findUnique).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects approval save when manifest revision changes after row lock', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const decision = manifest.decisions.find(
+      (d) => d.section === 'publications' && d.action === 'manual-review',
+    );
+    expect(decision).toBeDefined();
+    if (!decision) {
+      throw new Error('Expected a publications manual-review decision for this fixture.');
+    }
+    const staleEnvelope = {
+      ...envelope,
+      manifestRevision: 'deadbeefdeadbeefdeadbeefdeadbeef',
+    };
+
+    vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
+      id: IMPORT_ID,
+      status: 'PARSED',
+      candidatePayload: payload,
+      reviewManifest: envelope,
+      reviewApprovals: null,
+    } as never);
+
+    const { callOrder, update } = mockApprovalSaveTransaction({
+      importId: IMPORT_ID,
+      row: {
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: staleEnvelope,
+        reviewApprovals: null,
+      },
+    });
+
+    await expect(
+      saveImportReviewApprovals({
+        importId: IMPORT_ID,
+        manifestRevision: envelope.manifestRevision,
+        approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+      }),
+    ).rejects.toMatchObject({ code: 'CONCURRENT_UPDATE' });
+    expect(callOrder).toEqual(['lock', 'read']);
+    expect(update).not.toHaveBeenCalled();
   });
 
   it('documents allowed import statuses for review approval updates', () => {

--- a/src/tests/imports/importCandidateReviewWorkflow.test.ts
+++ b/src/tests/imports/importCandidateReviewWorkflow.test.ts
@@ -1,0 +1,287 @@
+/** @vitest-environment node */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/server/db/prisma', () => ({
+  prisma: {
+    contentImport: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock('@/server/content/contentEvents', () => ({
+  recordContentEvent: vi.fn(),
+}));
+
+vi.mock('@/server/content/contentWorkflowCore', async () => {
+  const actual = await vi.importActual('@/server/content/contentWorkflowCore');
+  return {
+    ...(actual as Record<string, unknown>),
+    getWorkingDraft: vi.fn(),
+    getLatestPublishedVersion: vi.fn(),
+  };
+});
+
+import { SITE_CONTENT_RAW } from '@/content/defaults';
+import { assertSiteContent } from '@/content/validators';
+import { recordContentEvent } from '@/server/content/contentEvents';
+import { getLatestPublishedVersion, getWorkingDraft } from '@/server/content/contentWorkflowCore';
+import { prisma } from '@/server/db/prisma';
+import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
+import { CandidateReviewApprovalError } from '@/server/imports/candidateReviewValidate';
+import { countUnresolvedBlockingDecisions } from '@/server/imports/importCandidateReview/gate';
+import {
+  generateImportReviewManifest,
+  summarizeReviewManifestForAudit,
+} from '@/server/imports/importCandidateReview/generate';
+import { computeImportReviewManifestRevision } from '@/server/imports/importCandidateReview/revision';
+import {
+  saveImportReviewApprovals,
+} from '@/server/imports/importCandidateReview/service';
+import {
+  parseStoredReviewApprovals,
+  parseStoredReviewManifest,
+  toStoredApprovalsEnvelope,
+} from '@/server/imports/importCandidateReview/storageSchema';
+import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
+
+const IMPORT_ID = 'imp-review-workflow';
+
+function envelopeFromDetails(details = minimalImportDetails(), rawDocumentText = 'cv body text for hash') {
+  return buildImportCandidatePayload({
+    rawDocumentText,
+    parserVersion: 't',
+    details,
+    sections: [],
+    importWarnings: [],
+  });
+}
+
+describe('import candidate review storage', () => {
+  beforeEach(() => {
+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+    vi.mocked(getLatestPublishedVersion).mockResolvedValue(null);
+  });
+
+  it('validates stored manifest envelope', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    expect(parseStoredReviewManifest(envelope)).not.toBeNull();
+    expect(envelope.manifestRevision).toHaveLength(32);
+    expect(manifest.decisions.length).toBeGreaterThanOrEqual(0);
+    const summary = summarizeReviewManifestForAudit(manifest);
+    expect(summary.decisionCount).toBe(manifest.decisions.length);
+  });
+
+  it('rejects stale manifest revision submissions', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const decision = manifest.decisions.find((d) => d.action === 'manual-review');
+    if (!decision) {
+      return;
+    }
+    vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
+      id: IMPORT_ID,
+      status: 'PARSED',
+      candidatePayload: payload,
+      reviewManifest: envelope,
+      reviewApprovals: null,
+    } as never);
+
+    await expect(
+      saveImportReviewApprovals({
+        importId: IMPORT_ID,
+        manifestRevision: 'deadbeefdeadbeefdeadbeefdeadbeef',
+        approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+      }),
+    ).rejects.toMatchObject({ code: 'REVIEW_MANIFEST_STALE' });
+  });
+
+  it('persists approvals transactionally and records audit event', async () => {
+    const candidate = minimalImportDetails();
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const decision = manifest.decisions.find(
+      (d) => d.section === 'publications' && d.action === 'manual-review',
+    );
+    if (!decision) {
+      return;
+    }
+    const approvalsEnvelope = toStoredApprovalsEnvelope({
+      manifestRevision: envelope.manifestRevision,
+      approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+    });
+
+    vi.mocked(prisma.contentImport.findUnique)
+      .mockResolvedValueOnce({
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: null,
+      } as never)
+      .mockResolvedValueOnce({
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: approvalsEnvelope,
+      } as never)
+      .mockResolvedValueOnce({
+        id: IMPORT_ID,
+        status: 'PARSED',
+        candidatePayload: payload,
+        reviewManifest: envelope,
+        reviewApprovals: approvalsEnvelope,
+      } as never);
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
+      const tx = {
+        contentImport: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: IMPORT_ID,
+            status: 'PARSED',
+            candidatePayload: payload,
+            reviewManifest: envelope,
+            reviewApprovals: null,
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+      };
+      return fn(tx as never);
+    });
+
+    const state = await saveImportReviewApprovals({
+      importId: IMPORT_ID,
+      manifestRevision: envelope.manifestRevision,
+      approvals: [{ decisionId: decision.decisionId, approvedAction: 'skip' }],
+    });
+    expect(state?.approvals).toHaveLength(1);
+    expect(recordContentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'SYSTEM_NOTE',
+        payload: expect.objectContaining({ kind: 'IMPORT_REVIEW_APPROVALS_UPDATED' }),
+      }),
+    );
+  });
+
+  it('rejects advisory patent approvals', async () => {
+    const candidate = minimalImportDetails({
+      patents: [
+        {
+          id: 'p1',
+          title: 'Patent',
+          number: '1',
+          country: 'US',
+          date: null,
+          inventors: null,
+          status: null,
+          type: 'international',
+          raw: null,
+        },
+      ],
+    });
+    const payload = envelopeFromDetails(candidate);
+    const { envelope, manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const patentDecision = manifest.decisions.find((d) => d.section === 'patents');
+    expect(patentDecision).toBeDefined();
+    vi.mocked(prisma.contentImport.findUnique).mockResolvedValue({
+      id: IMPORT_ID,
+      status: 'PARSED',
+      candidatePayload: payload,
+      reviewManifest: envelope,
+      reviewApprovals: null,
+    } as never);
+
+    await expect(
+      saveImportReviewApprovals({
+        importId: IMPORT_ID,
+        manifestRevision: envelope.manifestRevision,
+        approvals: [{ decisionId: patentDecision!.decisionId, approvedAction: 'skip' }],
+      }),
+    ).rejects.toBeInstanceOf(CandidateReviewApprovalError);
+  });
+
+  it('clears approvals when manifest revision changes', () => {
+    const revisionA = computeImportReviewManifestRevision({
+      sourceTextHash: 'hash-a',
+      decisionIds: ['a:1', 'a:2'],
+    });
+    const revisionB = computeImportReviewManifestRevision({
+      sourceTextHash: 'hash-b',
+      decisionIds: ['a:1', 'a:2'],
+    });
+    expect(revisionA).not.toBe(revisionB);
+    const approvals = toStoredApprovalsEnvelope({
+      manifestRevision: revisionA,
+      approvals: [{ decisionId: 'a:1', approvedAction: 'skip' }],
+    });
+    expect(parseStoredReviewApprovals(approvals)?.manifestRevision).toBe(revisionA);
+  });
+
+  it('advisory patent decisions do not block merge accounting count', async () => {
+    const baseline = assertSiteContent(SITE_CONTENT_RAW);
+    const candidate = minimalImportDetails({
+      patents: [
+        {
+          id: 'p1',
+          title: 'Patent',
+          number: '1',
+          country: 'US',
+          date: null,
+          inventors: null,
+          status: null,
+          type: 'international',
+          raw: null,
+        },
+      ],
+    });
+    const payload = envelopeFromDetails(candidate);
+    const { manifest } = await generateImportReviewManifest({
+      importId: IMPORT_ID,
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    expect(manifest.accounting.patents.unresolvedAdvisoryDecisions).toBeGreaterThan(0);
+    expect(countUnresolvedBlockingDecisions(manifest)).toBe(
+      manifest.accounting.publications.unresolvedManualReview +
+        manifest.accounting.awards.unresolvedManualReview,
+    );
+    void baseline;
+  });
+});
+
+describe('import candidate review API auth', () => {
+  it('review-approvals route module exports POST handler', async () => {
+    const mod = await import('@/app/api/admin/imports/[id]/review-approvals/route');
+    expect(typeof mod.POST).toBe('function');
+  });
+});

--- a/src/tests/imports/importsDomain.test.ts
+++ b/src/tests/imports/importsDomain.test.ts
@@ -3,6 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('server-only', () => ({}));
 
+vi.mock('@/server/content/contentWorkflowCore', async () => {
+  const actual = await vi.importActual('@/server/content/contentWorkflowCore');
+  return {
+    ...(actual as Record<string, unknown>),
+    getWorkingDraft: vi.fn().mockResolvedValue(null),
+    getLatestPublishedVersion: vi.fn().mockResolvedValue(null),
+  };
+});
+
 vi.mock('@/server/db/prisma', () => ({
   prisma: {
     uploadedFile: { findUnique: vi.fn(), create: vi.fn() },
@@ -13,14 +22,18 @@ vi.mock('@/server/db/prisma', () => ({
 
 import { prisma } from '@/server/db/prisma';
 import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
+import { generateImportReviewManifest } from '@/server/imports/importCandidateReview/generate';
+import * as reconcileModule from '@/server/imports/importCandidateReview/reconcile';
+import { toStoredApprovalsEnvelope } from '@/server/imports/importCandidateReview/storageSchema';
 import { isTerminalImportStatus } from '@/server/imports/importStatus';
 import {
   createContentImportRecord,
   saveImportCandidateAndWarnings,
   updateImportStatus,
 } from '@/server/imports/repository';
-import { parseImportWarnings, toImportDetail, toImportSummary } from '@/server/imports/serialize';
+import { parseImportWarnings, toImportDetail, toImportSummary, buildImportCandidateReconcileReview } from '@/server/imports/serialize';
 import { ImportDomainError } from '@/server/imports/types';
+import { minimalImportDetails as fixtureImportDetails } from '@/tests/fixtures/minimalImportDetails';
 import type { DetectedSection } from '@/types/parser';
 import { validateDetails } from '@/validators/detailsSchema';
 
@@ -130,6 +143,96 @@ describe('importsDomain', () => {
     });
     expect(detail.candidateReview).toBeNull();
     expect(detail.candidateReconcileReview).toBeNull();
+  });
+
+  it('toImportDetail returns corrupted reconciliation DTO for malformed stored approvals', async () => {
+    const candidate = fixtureImportDetails();
+    const payload = buildImportCandidatePayload({
+      rawDocumentText: 'cv body',
+      parserVersion: '1',
+      details: candidate,
+      sections: [],
+      importWarnings: [],
+    });
+    const { envelope } = await generateImportReviewManifest({
+      importId: 'imp-corrupt',
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const createdAt = new Date('2026-01-02T03:04:05.000Z');
+    const updatedAt = new Date('2026-01-03T03:04:05.000Z');
+    const row = {
+      id: 'imp-corrupt',
+      uploadedFileId: 'up1',
+      status: 'PARSED' as const,
+      parserVersion: '1',
+      warnings: [],
+      rawPreviewPath: null,
+      rawExtract: null,
+      candidatePayload: payload as unknown as Prisma.JsonValue,
+      reviewManifest: envelope,
+      reviewApprovals: { corrupted: true },
+      createdAt,
+      updatedAt,
+      uploadedFile: {
+        id: 'up1',
+        originalName: 'cv.docx',
+        storedPath: '/files/cv.docx',
+        mimeType: 'application/whatever',
+        sizeBytes: 10,
+        sha256: 'abc',
+        sourceFormat: 'DOCX' as const,
+        uploadedAt: createdAt,
+      },
+      versions: [],
+    };
+    const detail = toImportDetail(row);
+    expect(detail.candidateReconcileReview).not.toBeNull();
+    expect(detail.candidateReconcileReview!.loadError?.code).toBe('REVIEW_APPROVALS_INVALID');
+    expect(detail.candidateReconcileReview!.mergeReviewBlocked).toBe(true);
+    expect(detail.candidateReconcileReview!.hasManifest).toBe(true);
+  });
+
+  it('buildImportCandidateReconcileReview returns stale approvals load error without throwing', async () => {
+    const candidate = fixtureImportDetails();
+    const payload = buildImportCandidatePayload({
+      rawDocumentText: 'cv body',
+      parserVersion: '1',
+      details: candidate,
+      sections: [],
+      importWarnings: [],
+    });
+    const { envelope } = await generateImportReviewManifest({
+      importId: 'imp-stale',
+      sourceFileName: 'cv.docx',
+      sourceTextHash: payload.sourceTextHash,
+      candidate,
+    });
+    const staleApprovals = toStoredApprovalsEnvelope({
+      manifestRevision: 'deadbeefdeadbeefdeadbeefdeadbeef',
+      approvals: [],
+    });
+    const review = buildImportCandidateReconcileReview({
+      reviewManifest: envelope,
+      reviewApprovals: staleApprovals,
+    });
+    expect(review).not.toBeNull();
+    expect(review!.loadError?.code).toBe('REVIEW_APPROVALS_STALE');
+    expect(review!.mergeReviewBlocked).toBe(true);
+  });
+
+  it('buildImportCandidateReconcileReview does not swallow unknown programming errors', async () => {
+    const spy = vi.spyOn(reconcileModule, 'loadImportReviewStateFromRow').mockImplementation(() => {
+      throw new Error('unexpected programming failure');
+    });
+    expect(() =>
+      buildImportCandidateReconcileReview({
+        reviewManifest: { storageVersion: 1 },
+        reviewApprovals: null,
+      }),
+    ).toThrow('unexpected programming failure');
+    spy.mockRestore();
   });
 
   it('toImportDetail has null candidateReview for malformed candidatePayload', () => {

--- a/src/tests/imports/importsDomain.test.ts
+++ b/src/tests/imports/importsDomain.test.ts
@@ -92,6 +92,8 @@ describe('importsDomain', () => {
       rawPreviewPath: null,
       rawExtract: { a: 1 },
       candidatePayload: minimalImportDetails,
+      reviewManifest: null,
+      reviewApprovals: null,
       createdAt,
       updatedAt,
       uploadedFile: {
@@ -141,6 +143,8 @@ describe('importsDomain', () => {
       rawPreviewPath: null,
       rawExtract: null,
       candidatePayload: { notValidDetails: true },
+      reviewManifest: null,
+      reviewApprovals: null,
       createdAt,
       updatedAt,
       uploadedFile: {
@@ -184,6 +188,8 @@ describe('importsDomain', () => {
       rawPreviewPath: null,
       rawExtract: null,
       candidatePayload: envelope as unknown as Prisma.JsonValue,
+      reviewManifest: null,
+      reviewApprovals: null,
       createdAt,
       updatedAt,
       uploadedFile: {
@@ -244,6 +250,8 @@ describe('imports repository (mocked prisma)', () => {
       rawPreviewPath: null,
       rawExtract: null,
       candidatePayload: null,
+      reviewManifest: null,
+      reviewApprovals: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -273,6 +281,8 @@ describe('imports repository (mocked prisma)', () => {
       rawPreviewPath: null,
       rawExtract: null,
       candidatePayload: { x: 1 },
+      reviewManifest: null,
+      reviewApprovals: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     });

--- a/src/tests/imports/importsDomain.test.ts
+++ b/src/tests/imports/importsDomain.test.ts
@@ -129,6 +129,7 @@ describe('importsDomain', () => {
       rawHtmlTruncated: false,
     });
     expect(detail.candidateReview).toBeNull();
+    expect(detail.candidateReconcileReview).toBeNull();
   });
 
   it('toImportDetail has null candidateReview for malformed candidatePayload', () => {
@@ -162,6 +163,7 @@ describe('importsDomain', () => {
     const detail = toImportDetail(row);
     expect(detail.candidateReview).toBeNull();
     expect(detail.candidateSummary).toBeNull();
+    expect(detail.candidateReconcileReview).toBeNull();
   });
 
   it('toImportDetail includes candidateReview for envelope payloads', () => {
@@ -215,6 +217,7 @@ describe('importsDomain', () => {
     const patentEntry = detail.candidateReview!.countValidation.entries.find((e) => e.code === 'PATENT_COUNT_MISMATCH');
     expect(patentEntry).toBeDefined();
     expect(patentEntry!.severity).toBe('warning');
+    expect(detail.candidateReconcileReview).toBeNull();
   });
 });
 

--- a/src/tests/imports/mergeImportToDraft.test.ts
+++ b/src/tests/imports/mergeImportToDraft.test.ts
@@ -29,12 +29,19 @@ vi.mock('@/server/content/contentWorkflowCore', async () => {
   };
 });
 
+vi.mock('@/server/imports/importCandidateReview/service', () => ({
+  ensureImportReviewManifest: vi.fn(),
+}));
+
 import { SITE_CONTENT_RAW } from '@/content/defaults';
 import { assertSiteContent, validateSiteContent } from '@/content/validators';
 import { getWorkingDraft } from '@/server/content/contentWorkflowCore';
 import { prisma } from '@/server/db/prisma';
 import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
 import { CV_NARRATIVE_LIST_ITEM_PREFIX } from '@/server/imports/cvNarrativeToSimpleLists';
+import { generateImportReviewManifest } from '@/server/imports/importCandidateReview/generate';
+import { ensureImportReviewManifest } from '@/server/imports/importCandidateReview/service';
+import { toStoredApprovalsEnvelope } from '@/server/imports/importCandidateReview/storageSchema';
 import { ImportMergeError, mergeImportCandidateToWorkingDraft } from '@/server/imports/mergeImportToDraft';
 import { getContentImportDetail, updateImportStatus } from '@/server/imports/repository';
 import { minimalImportDetails } from '@/tests/fixtures/minimalImportDetails';
@@ -47,7 +54,46 @@ describe('mergeImportCandidateToWorkingDraft', () => {
     vi.mocked(prisma.contentVersion.update).mockReset();
     vi.mocked(prisma.contentVersion.findFirst).mockReset();
     vi.mocked(getWorkingDraft).mockReset();
+    vi.mocked(ensureImportReviewManifest).mockReset();
   });
+
+  async function attachReviewManifest<T extends Record<string, unknown>>(
+    row: T,
+    details: ReturnType<typeof minimalImportDetails>,
+    importId: string,
+    rawDocumentText = 'body',
+  ) {
+    const envelope = buildImportCandidatePayload({
+      rawDocumentText,
+      parserVersion: 't',
+      details,
+      sections: [],
+      importWarnings: [],
+    });
+    const { envelope: reviewEnvelope, manifest } = await generateImportReviewManifest({
+      importId,
+      sourceFileName: 't.docx',
+      sourceTextHash: envelope.sourceTextHash,
+      candidate: details,
+    });
+    const blockingApprovals = manifest.decisions
+      .filter((d) => (d.action === 'manual-review' || d.action === 'remove-artifact') && d.section !== 'patents' && d.section !== 'research')
+      .map((d) => ({ decisionId: d.decisionId, approvedAction: 'skip' as const }));
+    const approvalsEnvelope =
+      blockingApprovals.length > 0
+        ? toStoredApprovalsEnvelope({
+            manifestRevision: reviewEnvelope.manifestRevision,
+            approvals: blockingApprovals,
+          })
+        : null;
+    vi.mocked(ensureImportReviewManifest).mockResolvedValue(reviewEnvelope);
+    return {
+      ...row,
+      candidatePayload: envelope,
+      reviewManifest: reviewEnvelope,
+      reviewApprovals: approvalsEnvelope,
+    };
+  }
 
   it('returns idempotent success when import already MERGED and a working draft exists', async () => {
     vi.mocked(getContentImportDetail).mockResolvedValue({
@@ -100,21 +146,18 @@ describe('mergeImportCandidateToWorkingDraft', () => {
     const details = minimalImportDetails({
       profile: { ...minimalImportDetails().profile, name: 'Re-merge Name' },
     });
-    const envelope = buildImportCandidatePayload({
-      rawDocumentText: 'body',
-      parserVersion: 't',
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-remerge',
+        status: 'MERGED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
       details,
-      sections: [],
-      importWarnings: [],
-    });
-    vi.mocked(getContentImportDetail).mockResolvedValue({
-      id: 'imp-remerge',
-      status: 'MERGED',
-      candidatePayload: envelope,
-      uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-      createdAt: new Date(),
-      versions: [],
-    } as never);
+      'imp-remerge',
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
     vi.mocked(prisma.contentVersion.findFirst).mockResolvedValueOnce(null);
     vi.mocked(getWorkingDraft).mockResolvedValue(null);
     vi.mocked(prisma.contentVersion.create).mockResolvedValue({
@@ -158,21 +201,19 @@ describe('mergeImportCandidateToWorkingDraft', () => {
       patents,
       counts: { publications: 0, patents: 5, projects: 0, awards: 0, students: 0 },
     });
-    const envelope = buildImportCandidatePayload({
-      rawDocumentText: raw,
-      parserVersion: 't',
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-pat',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
       details,
-      sections: [],
-      importWarnings: [],
-    });
-    vi.mocked(getContentImportDetail).mockResolvedValue({
-      id: 'imp-pat',
-      status: 'PARSED',
-      candidatePayload: envelope,
-      uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-      createdAt: new Date(),
-      versions: [],
-    } as never);
+      'imp-pat',
+      raw,
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
     vi.mocked(getWorkingDraft).mockResolvedValue(null);
     vi.mocked(prisma.contentVersion.create).mockResolvedValue({
       id: 'cv-new',
@@ -219,21 +260,19 @@ describe('mergeImportCandidateToWorkingDraft', () => {
       raw: null,
     }));
     const details = minimalImportDetails({ patents, counts: { publications: 0, patents: 5, projects: 0, awards: 0, students: 0 } });
-    const envelope = buildImportCandidatePayload({
-      rawDocumentText: raw,
-      parserVersion: 't',
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-ack',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
       details,
-      sections: [],
-      importWarnings: [],
-    });
-    vi.mocked(getContentImportDetail).mockResolvedValue({
-      id: 'imp-ack',
-      status: 'PARSED',
-      candidatePayload: envelope,
-      uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-      createdAt: new Date(),
-      versions: [],
-    } as never);
+      'imp-ack',
+      raw,
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
     vi.mocked(getWorkingDraft).mockResolvedValue(null);
 
     await expect(
@@ -275,21 +314,18 @@ describe('mergeImportCandidateToWorkingDraft', () => {
         ],
       },
     });
-    const envelope = buildImportCandidatePayload({
-      rawDocumentText: 'cv body',
-      parserVersion: 't',
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-nar',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
       details,
-      sections: [],
-      importWarnings: [],
-    });
-    vi.mocked(getContentImportDetail).mockResolvedValue({
-      id: 'imp-nar',
-      status: 'PARSED',
-      candidatePayload: envelope,
-      uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-      createdAt: new Date(),
-      versions: [],
-    } as never);
+      'imp-nar',
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
     vi.mocked(getWorkingDraft).mockResolvedValue(null);
     vi.mocked(prisma.contentVersion.create).mockResolvedValue({
       id: 'cv-nar',
@@ -335,21 +371,18 @@ describe('mergeImportCandidateToWorkingDraft', () => {
         ],
       },
     });
-    const envelope = buildImportCandidatePayload({
-      rawDocumentText: 'cv body',
-      parserVersion: 't',
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-nar-fr',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
       details,
-      sections: [],
-      importWarnings: [],
-    });
-    vi.mocked(getContentImportDetail).mockResolvedValue({
-      id: 'imp-nar-fr',
-      status: 'PARSED',
-      candidatePayload: envelope,
-      uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-      createdAt: new Date(),
-      versions: [],
-    } as never);
+      'imp-nar-fr',
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
     vi.mocked(getWorkingDraft).mockResolvedValue(null);
     vi.mocked(prisma.contentVersion.create).mockResolvedValue({
       id: 'cv-nar-fr',
@@ -400,21 +433,19 @@ describe('mergeImportCandidateToWorkingDraft', () => {
       raw: null,
     }));
     const details = minimalImportDetails({ patents, counts: { publications: 0, patents: 5, projects: 0, awards: 0, students: 0 } });
-    const envelope = buildImportCandidatePayload({
-      rawDocumentText: raw,
-      parserVersion: 't',
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-fr',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
       details,
-      sections: [],
-      importWarnings: [],
-    });
-    vi.mocked(getContentImportDetail).mockResolvedValue({
-      id: 'imp-fr',
-      status: 'PARSED',
-      candidatePayload: envelope,
-      uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
-      createdAt: new Date(),
-      versions: [],
-    } as never);
+      'imp-fr',
+      raw,
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
     vi.mocked(getWorkingDraft).mockResolvedValue(null);
     vi.mocked(prisma.contentVersion.create).mockResolvedValue({
       id: 'cv-fr',

--- a/src/tests/imports/mergeImportToDraft.test.ts
+++ b/src/tests/imports/mergeImportToDraft.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/server/imports/importCandidateReview/service', () => ({
 
 import { SITE_CONTENT_RAW } from '@/content/defaults';
 import { assertSiteContent, validateSiteContent } from '@/content/validators';
+import { recordContentEvent } from '@/server/content/contentEvents';
 import { getWorkingDraft } from '@/server/content/contentWorkflowCore';
 import { prisma } from '@/server/db/prisma';
 import { buildImportCandidatePayload } from '@/server/imports/candidatePayload/builder';
@@ -62,6 +63,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
     details: ReturnType<typeof minimalImportDetails>,
     importId: string,
     rawDocumentText = 'body',
+    options?: { resolveBlocking?: boolean },
   ) {
     const envelope = buildImportCandidatePayload({
       rawDocumentText,
@@ -80,7 +82,7 @@ describe('mergeImportCandidateToWorkingDraft', () => {
       .filter((d) => (d.action === 'manual-review' || d.action === 'remove-artifact') && d.section !== 'patents' && d.section !== 'research')
       .map((d) => ({ decisionId: d.decisionId, approvedAction: 'skip' as const }));
     const approvalsEnvelope =
-      blockingApprovals.length > 0
+      options?.resolveBlocking !== false && blockingApprovals.length > 0
         ? toStoredApprovalsEnvelope({
             manifestRevision: reviewEnvelope.manifestRevision,
             approvals: blockingApprovals,
@@ -476,5 +478,177 @@ describe('mergeImportCandidateToWorkingDraft', () => {
     if (validated.success) {
       expect(validated.data.patents.items).toHaveLength(5);
     }
+  });
+
+  it('rejects unresolved review override when reason is shorter than 8 characters', async () => {
+    const details = minimalImportDetails();
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-short-reason',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
+      details,
+      'imp-short-reason',
+      'body',
+      { resolveBlocking: false },
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+
+    await expect(
+      mergeImportCandidateToWorkingDraft({
+        importId: 'imp-short-reason',
+        action: 'create',
+        acknowledgeUnresolvedReview: true,
+        unresolvedReviewReason: 'short',
+      }),
+    ).rejects.toMatchObject({ code: 'MERGE_ACK_REQUIRED' });
+    expect(prisma.contentVersion.create).not.toHaveBeenCalled();
+  });
+
+  it('does not record override audit event when merge fails after acknowledgement', async () => {
+    vi.mocked(recordContentEvent).mockClear();
+    const details = minimalImportDetails();
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-fail-merge',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
+      details,
+      'imp-fail-merge',
+      'body',
+      { resolveBlocking: false },
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+    vi.mocked(prisma.contentVersion.create).mockRejectedValue(new Error('db failure'));
+
+    await expect(
+      mergeImportCandidateToWorkingDraft({
+        importId: 'imp-fail-merge',
+        action: 'create',
+        acknowledgeUnresolvedReview: true,
+        unresolvedReviewReason: 'Accepted risk for unresolved reconciliation decisions.',
+      }),
+    ).rejects.toThrow('db failure');
+
+    const overrideEvents = vi
+      .mocked(recordContentEvent)
+      .mock.calls.filter(
+        (call) =>
+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+      );
+    expect(overrideEvents).toHaveLength(0);
+  });
+
+  it('records exactly one override audit event after successful acknowledged merge', async () => {
+    vi.mocked(recordContentEvent).mockClear();
+    const details = minimalImportDetails();
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-override-ok',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
+      details,
+      'imp-override-ok',
+      'body',
+      { resolveBlocking: false },
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
+      id: 'cv-override',
+      status: 'DRAFT',
+      draftSlot: 'main',
+      importId: 'imp-override-ok',
+      payload: {},
+      label: null,
+      changeSummary: null,
+      createdBy: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      publishedAt: null,
+      publishSequence: null,
+    } as never);
+
+    await mergeImportCandidateToWorkingDraft({
+      importId: 'imp-override-ok',
+      action: 'create',
+      acknowledgeUnresolvedReview: true,
+      unresolvedReviewReason: '  Accepted risk for unresolved reconciliation decisions.  ',
+    });
+
+    const overrideEvents = vi
+      .mocked(recordContentEvent)
+      .mock.calls.filter(
+        (call) =>
+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+      );
+    expect(overrideEvents).toHaveLength(1);
+    expect(overrideEvents[0]?.[0]).toMatchObject({
+      versionId: 'cv-override',
+      payload: expect.objectContaining({
+        reason: 'Accepted risk for unresolved reconciliation decisions.',
+      }),
+    });
+  });
+
+  it('does not record override audit event when unresolved blocking count is zero', async () => {
+    vi.mocked(recordContentEvent).mockClear();
+    const details = minimalImportDetails();
+    const row = await attachReviewManifest(
+      {
+        id: 'imp-no-override',
+        status: 'PARSED',
+        uploadedFile: { originalName: 't.docx', storedPath: '/u/t', id: 'uf1' },
+        createdAt: new Date(),
+        versions: [],
+      },
+      details,
+      'imp-no-override',
+    );
+    vi.mocked(getContentImportDetail).mockResolvedValue(row as never);
+    vi.mocked(getWorkingDraft).mockResolvedValue(null);
+    vi.mocked(prisma.contentVersion.create).mockResolvedValue({
+      id: 'cv-no-override',
+      status: 'DRAFT',
+      draftSlot: 'main',
+      importId: 'imp-no-override',
+      payload: {},
+      label: null,
+      changeSummary: null,
+      createdBy: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      publishedAt: null,
+      publishSequence: null,
+    } as never);
+
+    await mergeImportCandidateToWorkingDraft({
+      importId: 'imp-no-override',
+      action: 'create',
+      acknowledgeUnresolvedReview: true,
+      unresolvedReviewReason: 'Should not be used when nothing is unresolved.',
+    });
+
+    const overrideEvents = vi
+      .mocked(recordContentEvent)
+      .mock.calls.filter(
+        (call) =>
+          (call[0] as { payload?: { kind?: string } }).payload?.kind ===
+          'IMPORT_MERGE_UNRESOLVED_REVIEW_OVERRIDE',
+      );
+    expect(overrideEvents).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Content / copy (CMS / seeds)
- [ ] Refactor (no intended behavior change)
- [ ] Docs / tooling only

## Checklist

- [ ] `npm run tsc`
- [ ] `npm run lint` (or note intentional exceptions)
- [ ] `npm run test:run`
- [ ] `npm run build` (if touching routes, server, or build config)
- [ ] No secrets / credentials committed
- [ ] If `SiteContent` shape changed: schema + seeds + `src/tests/content/siteContent.test.ts` updated

## Notes for reviewers

<!-- Migrations, env vars, publish/import implications, screenshots if UI changed intentionally -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added candidate import reconciliation review capability for admins to review baseline comparisons, resolve blocking decisions for publications and awards, and approve or reject artifact changes before merge
  * Added review approval workflow with audit trails that prevents merge completion when unresolved blocking decisions exist without explicit acknowledgment and reason

* **Tests**
  * Added comprehensive test coverage for review workflows, approval persistence, reconciliation UI, and baseline resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->